### PR TITLE
Some improvements to devtools-golang-v1beta1

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,3 +10,5 @@ extend-ignore =
     # This is required for typer
     # B008: Do not perform function calls in argument defaults.
     B008,
+per-file-ignores =
+    images/devtools-golang-v1beta1/tests/test_image.py:W191,E101

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,8 +14,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Cache xdg
         uses: actions/cache@v2
         with:
@@ -45,18 +43,18 @@ jobs:
           filters: |
             images:
               - 'images/**'
-      - name: Setup Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
-      - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v7
       - id: image-names
         shell: bash
         run: |
           image_names="$(printf "%s\n" ${{ steps.paths-filter.outputs.images_files }} | sed -E -e 's,^.*images/([^/]+)/.*$,\1,g' | sort | uniq | tr '\n' ' ')"
           declare -p image_names
           echo "::set-output name=image_names::${image_names}"
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Setup Poetry
+        uses: Gr1N/setup-poetry@v7
       - id: toolchain
         shell: bash
         run: |

--- a/images/devtools-golang-v1beta1/context/.golangci.yml
+++ b/images/devtools-golang-v1beta1/context/.golangci.yml
@@ -16,6 +16,7 @@ linters:
   - typecheck
   - unused
   - varcheck
+  - whitespace
 issues:
   exclude-use-default: false
   exclude-rules:

--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.44-alpine@sha256:e44ade2286749434ac58a90083b819ab19c4017c20a3d6ca2129fa669103f442 as golangci-lint
+FROM golangci/golangci-lint:v1.45-alpine@sha256:e44ade2286749434ac58a90083b819ab19c4017c20a3d6ca2129fa669103f442 as golangci-lint
 
 # golangci-lint does not work with go1.18
 # https://github.com/golangci/golangci-lint/issues/2649
@@ -16,7 +16,7 @@ RUN \
 COPY Makefile /usr/local/share/devtools-golang/Makefile
 COPY maker /usr/local/bin/maker
 
-COPY .golangci.yml /usr/local/share/devtools-golang/.golangci.yml
+COPY .golangci.yml /.golangci.yml
 
 RUN \
     ln -s /usr/local/bin/maker /usr/local/bin/help && \
@@ -24,6 +24,7 @@ RUN \
     ln -s /usr/local/bin/maker /usr/local/bin/validate-fix && \
     ln -s /usr/local/bin/maker /usr/local/bin/validate-static && \
     ln -s /usr/local/bin/maker /usr/local/bin/test && \
+    ln -s /usr/local/bin/maker /usr/local/bin/build && \
     true
 
 VOLUME /srv/workspace
@@ -31,4 +32,4 @@ WORKDIR /srv/workspace
 
 COPY --from=golangci-lint /usr/bin/golangci-lint /usr/bin/golangci-lint
 
-CMD ["validate"]
+CMD ["validate", "build"]

--- a/images/devtools-golang-v1beta1/context/Makefile
+++ b/images/devtools-golang-v1beta1/context/Makefile
@@ -1,10 +1,11 @@
+# https://www.gnu.org/software/make/manual/make.html
 SHELL=bash
 .SHELLFLAGS=-ec -o pipefail
 current_makefile:=$(lastword $(MAKEFILE_LIST))
 current_makefile_dir:=$(dir $(abspath $(current_makefile)))
 
 .PHONY: all
-all: validate validate-fix  ## Do everything (default target)
+all: validate  ## Do everything (default target)
 
 ########################################################################
 # boiler plate
@@ -16,6 +17,11 @@ dump_vars=$(foreach var,$(1),$(call dump_var,$(var)))
 else
 dump_var=
 dump_vars=
+endif
+
+ifneq ($(filter all targets,$(VERBOSE)),)
+__ORIGINAL_SHELL:=$(SHELL)
+SHELL=$(warning Building $@$(if $<, (from $<))$(if $?, ($? newer)))$(TIME) $(__ORIGINAL_SHELL)
 endif
 
 ########################################################################
@@ -32,7 +38,7 @@ XDG_CACHE_HOME?=$(HOME)/.cache
 # setting this so that it is more likely things will work on MacOS and Linux
 export POSIXLY_CORRECT:=1
 
-golangci_lint=golangci-lint $(if $(filter all commands,$(VERBOSE)),-v) --config /usr/local/share/devtools-golang/.golangci.yml
+golangci_lint=golangci-lint $(if $(filter all commands,$(VERBOSE)),-v)
 
 ########################################################################
 # targets ...
@@ -51,7 +57,38 @@ validate-static:  ## Static code validation
 
 .PHONY: test
 test:  ## Dynamic code validation
-	go test -race -cover $(if $(filter all commands,$(VERBOSE)),-v) ./...
+test coverage.out:
+	go test -race -cover $(if $(filter all commands,$(VERBOSE)),-v) ./... \
+		-coverprofile=coverage.out -covermode=atomic \
+		$(if $(gotest_files),$(gotest_files),./...) \
+		$(gotest_args)
+
+.PHONY: build
+build: ## build source
+	go build -race -v ./...
+
+.PHONY: view-coverage
+view-coverage: coverage.out ## view coverage
+	go tool cover -html=$(<)
+
+########################################################################
+# docker-lock
+########################################################################
+
+docker_compose=docker-compose
+docker_lock=$(docker_compose) run --rm -T docker-lock
+# docker_lock=docker-lock
+
+.PHONY: docker-lock
+docker-lock: ## Generate and rewrite digests of docker images
+	$(docker_lock) lock generate \
+		--update-existing-digests \
+		--dockerfile-globs *.Dockerfile Dockerfile Dockerfile.* \
+		--dockerfile-recursive \
+		--composefile-recursive \
+		--kubernetesfile-recursive \
+		--ignore-missing-digests
+	$(docker_lock) lock rewrite
 
 ########################################################################
 # utility

--- a/images/devtools-golang-v1beta1/tests/prototype/.gitignore
+++ b/images/devtools-golang-v1beta1/tests/prototype/.gitignore
@@ -1,0 +1,24 @@
+var/
+
+#### vimdiff <(curl --silent -L https://github.com/github/gitignore/raw/main/Go.gitignore) .gitignore
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/images/devtools-golang-v1beta1/tests/prototype/README.md
+++ b/images/devtools-golang-v1beta1/tests/prototype/README.md
@@ -1,0 +1,14 @@
+# ...
+
+## Developing
+
+```bash
+# build images
+docker-compose build
+# see available targets
+docker-compose run --rm devtools help
+# validate
+docker-compose run --rm devtools validate build VERBOSE=all
+# run in watch mode
+docker-compose run --rm devtools watch
+```

--- a/images/devtools-golang-v1beta1/tests/run
+++ b/images/devtools-golang-v1beta1/tests/run
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
 script_dirname="$( dirname -- "${0}" )"
-exec poetry run pytest "${script_dirname}" "${@}"
+cmd=(poetry run pytest "${script_dirname}" "${@}")
+printf " %q" "${cmd[@]}"; echo
+exec "${cmd[@]}"
+

--- a/images/devtools-golang-v1beta1/tests/test_image.py
+++ b/images/devtools-golang-v1beta1/tests/test_image.py
@@ -8,14 +8,14 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path, PurePath
 from pytest import CaptureFixture
-from textwrap import dedent
-from typing import Iterator, TypeVar, Union
+from typing import Dict, Iterator, List, Optional, TypeVar, Union
 
 TEST_DIR = Path(__file__).parent.absolute()
 PROTOTYPE_DIR = TEST_DIR / "prototype"
 
 PathLike = Union[PurePath, str]
 PathLikeT = TypeVar("PathLikeT", bound=PathLike)
+
 
 @contextmanager
 def ctx_prototype(tmp_path: Path) -> Iterator[Path]:
@@ -26,6 +26,7 @@ def ctx_prototype(tmp_path: Path) -> Iterator[Path]:
     with ctx_chdir(workdir):
         yield workdir
 
+
 @contextmanager
 def ctx_chdir(newdir: PathLikeT) -> Iterator[PathLikeT]:
     cwd = os.getcwd()
@@ -35,12 +36,21 @@ def ctx_chdir(newdir: PathLikeT) -> Iterator[PathLikeT]:
     finally:
         os.chdir(cwd)
 
+
 def test_prototype_ok() -> None:
     with ctx_chdir(PROTOTYPE_DIR):
         subprocess.run("docker-compose run --rm devtools".split(" "), check=True)
+        assert (PROTOTYPE_DIR / "coverage.out").exists()
 
-@pytest.mark.parametrize("code,error_msg", [
-    ("""\
+
+@pytest.mark.parametrize(
+    ["command", "success", "files", "expected_outputs"],
+    [
+        (
+            None,
+            False,
+            {
+                "bad_file.go": """\
 package main
 
 func NoDocs() int {
@@ -50,10 +60,15 @@ func NoDocs() int {
 func init() {
 	print(NoDocs())
 }
-""",
-    "exported function NoDocs should have comment or be unexported",
-    ),
-    ("""\
+"""
+            },
+            ["exported function NoDocs should have comment or be unexported"],
+        ),
+        (
+            None,
+            False,
+            {
+                "bad_file.go": """\
 package main
 
 import "fmt"
@@ -68,28 +83,57 @@ func init() {
 	print(x)
 }
 """,
-    "Error return value is not checked",
-    ),
-    ("""\
+            },
+            ["Error return value is not checked"],
+        ),
+        (
+            None,
+            False,
+            {
+                "bad_file.go": """\
 package main
 
 func UnusedFunc() int {
 	return 3
 }
-""",
-    "`UnusedFunc` is unused",
-    ),
-])
-def test_prototype_linter_errors(
+"""
+            },
+            ["`UnusedFunc` is unused"],
+        ),
+        (
+            None,
+            True,
+            {
+                ".golangci.yml": """\
+linters:
+  disable-all: true
+  enable: [ misspell ]
+"""
+            },
+            [""],
+        ),
+    ],
+)
+def test_alterations(
     tmp_path: Path,
     capfd: CaptureFixture[str],
-    code,
-    error_msg,
+    command: Optional[List[str]],
+    success: bool,
+    files: Optional[Dict[str, str]],
+    expected_outputs: List[str],
 ) -> None:
+    if command is None:
+        command = "docker-compose run --rm devtools".split(" ")
+    if files is None:
+        files = {}
     with ctx_prototype(tmp_path) as workdir:
-        (workdir / "bad_file.go").write_text(code)
-        with pytest.raises(subprocess.CalledProcessError):
-            subprocess.run("docker-compose run --rm devtools".split(" "), check=True)
+        for file_name, file_content in files.items():
+            (workdir / file_name).write_text(file_content)
+        if success:
+            subprocess.run(command, check=True)
+        else:
+            with pytest.raises(subprocess.CalledProcessError):
+                subprocess.run(command, check=True)
         captured = capfd.readouterr()
         with capfd.disabled():
             sys.stdout.write("captured.out:\n")
@@ -97,11 +141,14 @@ def test_prototype_linter_errors(
             sys.stderr.write("captured.err:\n")
             sys.stderr.write(captured.err)
 
-        assert error_msg in captured.out
+        for expected_output in expected_outputs:
+            assert expected_output in (captured.out + captured.err)
+
 
 def test_prototype_failing_tests(tmp_path: Path, capfd: CaptureFixture[str]) -> None:
     with ctx_prototype(tmp_path) as workdir:
-        (workdir / "sum/failing_test.go").write_text("""\
+        (workdir / "sum/failing_test.go").write_text(
+            """\
 package sum_test
 
 import "testing"
@@ -122,9 +169,11 @@ func TestThatFails(t *testing.T) {
 
         assert "FAIL: TestThatFails" in captured.out
 
+
 def test_prototype_validate_fix(tmp_path: Path) -> None:
     with ctx_prototype(tmp_path) as workdir:
-        (workdir / "bad_file.go").write_text("""\
+        (workdir / "bad_file.go").write_text(
+            """\
 package main
 
 import "fmt"
@@ -144,7 +193,9 @@ func init() {
 }
 """
         )
-        subprocess.run("docker-compose run --rm devtools validate-fix".split(" "), check=True)
+        subprocess.run(
+            "docker-compose run --rm devtools validate-fix".split(" "), check=True
+        )
 
         formatted_file = """\
 package main


### PR DESCRIPTION
- Setup golangci config so it can be overwritten by users.
- Add build target which just compiles things, and make this part of the
  default targets.
- Generate `coverage.out` on test
- Add a `README.md` to  `images/devtools-golang-v1beta1/tests/prototype/`
  so it makes for a better example.
