### PR TITLE
Improve `docker-lock` behaviour.

### DIFF
--- a/.docker-lock.yml
+++ b/.docker-lock.yml
@@ -1,0 +1,9 @@
+# https://github.com/safe-waters/docker-lock/blob/master/.docker-lock.example.yml
+generate:
+  base-dir: .
+  composefiles:
+    - docker-compose.yml
+  dockerfile-globs:
+    - 'images/**/Dockerfile'
+  dockerfile-recursive: true
+  update-existing-digests: true

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ IMAGE_NAMES?=$(notdir $(wildcard $(images_dir)/*))
 $(call dump_vars,IMAGE_NAMES)
 
 docker=docker
-docker_compose=docker-compose
+docker_compose=docker compose
 # docker_image_build_cmd=$(docker) image build
 docker_image_build_cmd=$(docker) buildx build --progress plain --load
 docker_image_build_args?=
@@ -145,19 +145,17 @@ load-any-images: | $(oci_output_dir)/ ## Loads any images that are found
 # docker-lock
 ########################################################################
 
-# docker_lock=$(docker_compose) run --rm -T docker-lock
-docker_lock=docker-lock
+docker_lock=$(docker_compose) run --rm -T docker-lock
+#docker_lock=docker-lock
 
 .PHONY: docker-lock
 docker-lock: ## Generate and rewrite digests of docker images
-	$(docker_lock) lock generate \
-		--update-existing-digests \
-		--dockerfile-globs *.Dockerfile Dockerfile Dockerfile.* \
-		--dockerfile-recursive \
-		--composefile-recursive \
-		--kubernetesfile-recursive \
-		--ignore-missing-digests
+	$(docker_lock) lock generate
 	$(docker_lock) lock rewrite
+
+.PHONY: validate-images-digests
+validate-images-digests:  ## Validate images digests
+	$(docker_lock) lock verify
 
 ########################################################################
 # utility

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,11 @@ services:
     ports:
       - "127.0.0.1:32604:32604"
   hadolint:
-    image: ghcr.io/hadolint/hadolint:2.8.0-alpine@sha256:6c4b7c23f96339489dd35f21a711996d7ce63047467a9a562287748a03ad5242
+    image: ghcr.io/hadolint/hadolint:latest@sha256:6c9e9654461b7cf81e1797d4ece13942207e0a92d1a33c8e0275260d39d61e6a
     volumes:
       - .hadolint.yaml:/.hadolint.yaml:z
   dockle:
-    image: docker.io/goodwithtech/dockle:v0.4.3@sha256:6771d453cdeaad77ae5bb0cd75ba1637243108fae7f2caa393ae63035cb88721
+    image: docker.io/goodwithtech/dockle:latest@sha256:ebd36f6c92ac850408c7cbbf1eddf97e53565da9d661c5fb8ec184ad82a5358d
     volumes:
       - ./var/oci-images:/srv/images:ro,z
   docker-lock:

--- a/docker-lock.json
+++ b/docker-lock.json
@@ -4,7 +4,7 @@
 			{
 				"name": "docker.io/library/ubuntu",
 				"tag": "20.04",
-				"digest": "8ae9bafbb64f63a50caab98fd3a5e37b3eb837a3e0780b78e5218e63193961f9",
+				"digest": "bea6d19168bbfd6af8d77c2cc3c572114eb5d113e6f422573c93cb605a0e2ffb",
 				"dockerfile": "Dockerfile.devtools",
 				"service": "devtools"
 			},
@@ -16,28 +16,32 @@
 			},
 			{
 				"name": "docker.io/goodwithtech/dockle",
-				"tag": "v0.4.3",
-				"digest": "6771d453cdeaad77ae5bb0cd75ba1637243108fae7f2caa393ae63035cb88721",
+				"tag": "latest",
+				"digest": "ebd36f6c92ac850408c7cbbf1eddf97e53565da9d661c5fb8ec184ad82a5358d",
 				"service": "dockle"
 			},
 			{
 				"name": "ghcr.io/hadolint/hadolint",
-				"tag": "2.8.0-alpine",
-				"digest": "6c4b7c23f96339489dd35f21a711996d7ce63047467a9a562287748a03ad5242",
+				"tag": "latest",
+				"digest": "6c9e9654461b7cf81e1797d4ece13942207e0a92d1a33c8e0275260d39d61e6a",
 				"service": "hadolint"
-			}
-		],
-		"images/devtools-terraform/tests/prototype/docker-compose.yaml": [
-			{
-				"name": "ocreg.invalid/coopnorge/engineering/image/devtools-terraform",
-				"tag": "built",
-				"digest": "",
-				"service": "devtools"
 			}
 		]
 	},
 	"dockerfiles": {
-		"images/devtools-terraform/context/Dockerfile": [
+		"images/devtools-golang-v1beta1/context/Dockerfile": [
+			{
+				"name": "golangci/golangci-lint",
+				"tag": "v1.45-alpine",
+				"digest": "e2e0e2d5016a35e80cce1c78f294384e006f4dd9e36fe39f8792a22c5ebd58e5"
+			},
+			{
+				"name": "golang",
+				"tag": "1.17-buster",
+				"digest": "4a4f99be38fc652b55665f87115761e6fcbbdfd7fe60c1e48d11960682562edb"
+			}
+		],
+		"images/devtools-terraform-v1beta1/context/Dockerfile": [
 			{
 				"name": "ghcr.io/terraform-linters/tflint-bundle",
 				"tag": "v0.34.1.2",
@@ -55,13 +59,13 @@
 			},
 			{
 				"name": "docker.io/library/golang",
-				"tag": "latest",
-				"digest": "0906175f651d65550ab51876c06083868e17c8da5f76b46215016f4e5b5eaeff"
+				"tag": "1.17",
+				"digest": "fdc8c53f80fabdc23fdbc620486735ca780a5a486cd4534296a69ddb5b1e98dc"
 			},
 			{
 				"name": "docker.io/library/ubuntu",
 				"tag": "20.04",
-				"digest": "8ae9bafbb64f63a50caab98fd3a5e37b3eb837a3e0780b78e5218e63193961f9"
+				"digest": "bea6d19168bbfd6af8d77c2cc3c572114eb5d113e6f422573c93cb605a0e2ffb"
 			}
 		]
 	}

--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -1,8 +1,8 @@
-FROM golangci/golangci-lint:v1.45-alpine@sha256:e44ade2286749434ac58a90083b819ab19c4017c20a3d6ca2129fa669103f442 as golangci-lint
+FROM golangci/golangci-lint:v1.45-alpine@sha256:e2e0e2d5016a35e80cce1c78f294384e006f4dd9e36fe39f8792a22c5ebd58e5 as golangci-lint
 
 # golangci-lint does not work with go1.18
 # https://github.com/golangci/golangci-lint/issues/2649
-FROM golang:1.17-buster@sha256:645084f761154b6f9509f4f558993baceece127d9143371c3e6986cd0f777b59 as base
+FROM golang:1.17-buster@sha256:4a4f99be38fc652b55665f87115761e6fcbbdfd7fe60c1e48d11960682562edb as base
 
 RUN \
     apt-get update && \

--- a/images/devtools-terraform-v1beta1/context/Dockerfile
+++ b/images/devtools-terraform-v1beta1/context/Dockerfile
@@ -2,13 +2,13 @@
 FROM ghcr.io/terraform-linters/tflint-bundle:v0.34.1.2@sha256:25889a5d3738a97ba1fa1e72bdc1b05dd1e7087c58213597cb0e1ed30f52615a AS tflint
 FROM docker.io/aquasec/tfsec:v1.1@sha256:c867867e5eb038f8c3e9f0cf698c7b6158006ff68088273934718060c8c7002b AS tfsec
 FROM docker.io/hashicorp/terraform:1.1.6@sha256:6f68122ab2981c609d9a7ee9cd3ba5564e4b1bf9b26ca3bc3628c106f98e9c35 AS terraform
-FROM docker.io/library/golang:1.17@sha256:0906175f651d65550ab51876c06083868e17c8da5f76b46215016f4e5b5eaeff as golang
+FROM docker.io/library/golang:1.17@sha256:fdc8c53f80fabdc23fdbc620486735ca780a5a486cd4534296a69ddb5b1e98dc as golang
 
 RUN \
     go env > /usr/local/bin/goenv.sh && \
     true
 
-FROM docker.io/library/ubuntu:20.04@sha256:8ae9bafbb64f63a50caab98fd3a5e37b3eb837a3e0780b78e5218e63193961f9 AS base
+FROM docker.io/library/ubuntu:20.04@sha256:bea6d19168bbfd6af8d77c2cc3c572114eb5d113e6f422573c93cb605a0e2ffb AS base
 
 
 RUN \


### PR DESCRIPTION
1. Configure `.docker-lock.yml`.
2. Update tooling image tags to `latest`.
3. Use `docker compose` instead of `docker-compose`.

closes https://github.com/coopnorge/engineering-docker-images/issues/29