### PR TITLE
Tell dependabot to work specifically in image directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "images/devtools-golang-v1beta1/context/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "images/devtools-terraform-v1beta1/context/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
I don't think dependabot runs recursively, trying this to make it work.

Also:
- Update docker image versions with docker-lock
