### PR TITLE
Unpin OS package versions in Dockerfiles

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,6 @@
 ignored:
   - DL3003
   - SC1091
+  # Ignoring this as pinning versions essentially breaks the utility provided
+  # by dependabot and we can't pin ranges either.
+  - DL3008

--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -10,11 +10,11 @@ RUN \
     apt-get update && \
     apt-get install -y \
         --no-install-recommends \
-        make=4.2.1-1.2 \
-        socat=1.7.3.2-2 \
-        curl=7.64.0-4+deb10u2 \
-        ca-certificates=20200601~deb10u2 \
-        busybox=1:1.30.1-4 \
+        make \
+        socat \
+        curl \
+        ca-certificates \
+        busybox \
         && \
     rm -vr /var/lib/apt/lists/* && \
     true

--- a/images/devtools-terraform-v1beta1/context/Dockerfile
+++ b/images/devtools-terraform-v1beta1/context/Dockerfile
@@ -17,12 +17,12 @@ RUN \
     apt-get update && \
     apt-get install -y \
         --no-install-recommends \
-        make=4.2.1-1.2 \
-        socat=1.7.3.3-2 \
-        git=1:2.25.1-1ubuntu3.2 \
-        curl=7.68.0-1ubuntu2.7 \
-        ca-certificates=20210119~20.04.2 \
-        busybox=1:1.30.1-4ubuntu6.4 \
+        make \
+        socat \
+        git \
+        curl \
+        ca-certificates \
+        busybox \
         && \
     rm -vr /var/lib/apt/lists/* && \
     true


### PR DESCRIPTION
Pinning them does not work with dependabot, so removing the pinning and
ignoring unpinned version warning from hadolint.