### PR TITLE
Simplify terraform detect and fallback to current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,36 @@ Devtools images are intended for use in git repos to do validation and artifact 
 
   [Usage example](./images/devtools-terraform-v1beta1/tests/prototype/).
 
+#### Security Considerations for devtools
+
+**WARNING**: The devtools images should only be used with rootless docker or
+similar technologies.
+
+Devtools images are designed to be used with [rootless
+docker](https://docs.docker.com/engine/security/rootless/), as they have to be
+able to modify files on filesystem as the user that invokes them. One example
+of this is when they have to enforce fixing validation errors (i.e.
+`validation-fix` target), but this is also the case when they have to maintain
+state across invocations like inside `.terraform`.
+
+With rootless docker, all files of the user that runs the image is seen to the
+container as root, and the root user in the docker container translates to the
+invoking user. It is possible to assign non root ownership to files mounted
+into the container but these permissions are not persisted as there is no place
+for this permission to be persisted to, and the next time the same files are
+mounted into a container they will again just have root permission.
+
+To accomodate this situation default user of the containers is root, and using
+them with a different user than root will likely only work in very select and
+limited situations where they don't have to modify anything on disk. If these
+containers run with rootless docker this  does not present the same security
+risks as those presented by using the root user with docker daemon running as
+root, as there is no potential for privilige escalation beyond the priviliges
+of the invoking user, which is the exact privliges which the process in the
+docker container should have anyway in order to operate as intended. This being
+said, care should be taken to not use these images with a docker daemon that is
+running as root.
+
 ## Developing
 
 ### Image Tests

--- a/images/devtools-terraform-v1beta1/context/Dockerfile
+++ b/images/devtools-terraform-v1beta1/context/Dockerfile
@@ -35,6 +35,7 @@ RUN \
     ln -rs /usr/local/bin/maker /usr/local/bin/help && \
     ln -rs /usr/local/bin/maker /usr/local/bin/validate && \
     ln -rs /usr/local/bin/maker /usr/local/bin/validate-fix && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/terraform-reinit && \
     true
 
 VOLUME /srv/workspace
@@ -50,6 +51,10 @@ COPY --from=golang /usr/local/bin/goenv.sh /usr/local/bin/goenv.sh
 COPY --from=docker-lock /prod/docker-lock /usr/local/bin/docker-lock
 
 COPY terraform-switcher_${tfswitcher_version}_checksums.txt /var/tmp/terraform-switcher_${tfswitcher_version}_checksums.txt
+
+# Setting TF_PLUGIN_CACHE_DIR makes things a lot faster but this somehow
+# causes weird permission issues.
+# ENV TF_PLUGIN_CACHE_DIR=/root/.cache/terraform.d/plugin-cache
 
 ARG terraform_versions="0.15.5 1.0.11 1.1.7"
 

--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -37,12 +37,15 @@ export POSIXLY_CORRECT:=1
 ########################################################################
 
 # Find all directories that look like they are terraform root directories.
-tfdirs=$(shell find . -name .terraform -prune -o \( -name '*.tf' -print0 \) \
-	| xargs -0 grep -c required_version \
-	| awk -F: '($$2 != 0){ print $$1 }' \
-	| sed 's|/[^/]\{1,\}$$||g')
+TFDIRS_EXCLUDE?=%/examples %/example
+$(info TFDIRS_EXCLUDE=$(TFDIRS_EXCLUDE))
 
-$(call dump_vars,tfdirs)
+TFDIRS?=$(filter-out $(TFDIRS_EXCLUDE), \
+	$(or $(shell find . -name .terraform -prune -o \( -name '*.tf' -print \) \
+		| sed 's|/[^/]\{1,\}$$||g' \
+		| sort | uniq),.))
+
+$(info TFDIRS=$(TFDIRS))
 
 terraform=terraform
 
@@ -54,19 +57,21 @@ terraform=terraform
 
 tfsec=tfsec
 tflint=tflint --enable-plugin=google --enable-plugin=azurerm $(if $(filter all commands,$(VERBOSE)),--loglevel=trace)
-tfswitch=tfswitch
+tfswitch={ set +o pipefail; yes | tfswitch; }
 
 define tfdir_targets
 
 tf-reinit: tf-reinit-$(1)
 .PHONY: tf-reinit-$(1)
 tf-reinit-$(1):
+	$(if $(TF_PLUGIN_CACHE_DIR),mkdir -vp $(TF_PLUGIN_CACHE_DIR),)
 	cd $(1) && $$(tfswitch)
 	cd $(1) && $$(terraform) init -upgrade
 
 validate: validate-tf-$(1)
 .PHONY: validate-tf-$(1)
 validate-tf-$(1): | $(1)/.terraform
+	$(if $(TF_PLUGIN_CACHE_DIR),mkdir -vp $(TF_PLUGIN_CACHE_DIR),)
 	cd $(1) && $$(tfswitch)
 	cd $(1) && $$(terraform) fmt -check -recursive -diff
 	cd $(1) && $$(terraform) validate
@@ -79,9 +84,13 @@ endef
 all: validate
 validate: ## Validate code.
 
+.PHONY: tf-reinit
 tf-reinit: ## Reintialize terraform
 
-$(foreach tfdir,$(tfdirs),\
+.PHONY: terraform-reinit
+terraform-reinit: tf-reinit ## Reintialize terraform
+
+$(foreach tfdir,$(TFDIRS),\
     $(eval $(call tfdir_targets,$(tfdir))))
 
 .PHONY: validate-fix

--- a/images/devtools-terraform-v1beta1/tests/README.md
+++ b/images/devtools-terraform-v1beta1/tests/README.md
@@ -1,0 +1,13 @@
+
+
+```bash
+## Run from repo root
+
+# build image
+make IMAGE_NAMES=devtools-terraform-v1beta1 build
+
+# test image
+IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/devtools-terraform-v1beta1:built \
+RAPID_TEST=1 \
+poetry run pytest images/devtools-terraform-v1beta1/tests
+```

--- a/images/devtools-terraform-v1beta1/tests/prototype/eg_module/main.tf
+++ b/images/devtools-terraform-v1beta1/tests/prototype/eg_module/main.tf
@@ -1,0 +1,7 @@
+variable "value_in" {
+  type = string
+}
+
+output "value_out" {
+  value = var.value_in
+}

--- a/images/devtools-terraform-v1beta1/tests/prototype/example/example.tf
+++ b/images/devtools-terraform-v1beta1/tests/prototype/example/example.tf
@@ -1,0 +1,17 @@
+module "test_github_repo" {
+  count = var.environment == "production" ? 1 : 0
+
+  source  = "terraform.coop.no/coopnorge/repos/github"
+  version = "..."
+
+  name = "repo-name"
+
+  teams = {
+    "team-a" = {
+      permission = "push"
+    }
+    "team-b" = {
+      permission = "maintain"
+    }
+  }
+}

--- a/images/devtools-terraform-v1beta1/tests/prototype/examples/examples.tf
+++ b/images/devtools-terraform-v1beta1/tests/prototype/examples/examples.tf
@@ -1,0 +1,17 @@
+module "test_github_repo" {
+  count = var.environment == "production" ? 1 : 0
+
+  source  = "terraform.coop.no/coopnorge/repos/github"
+  version = "..."
+
+  name = "repo-name"
+
+  teams = {
+    "team-a" = {
+      permission = "push"
+    }
+    "team-b" = {
+      permission = "maintain"
+    }
+  }
+}

--- a/images/devtools-terraform-v1beta1/tests/prototype/main.tf
+++ b/images/devtools-terraform-v1beta1/tests/prototype/main.tf
@@ -7,3 +7,5 @@ resource "null_resource" "none" {
 #   role    = "roles/editor"
 #   member  = "jane@example.com"
 # }
+
+

--- a/images/devtools-terraform-v1beta1/tests/prototype/use_eg_module.tf
+++ b/images/devtools-terraform-v1beta1/tests/prototype/use_eg_module.tf
@@ -1,0 +1,4 @@
+module "eg_module_hello" {
+  source   = "./eg_module"
+  value_in = "helloworld"
+}

--- a/images/devtools-terraform-v1beta1/tests/run
+++ b/images/devtools-terraform-v1beta1/tests/run
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 script_dirname="$( dirname -- "${0}" )"
+set -x
 exec poetry run pytest "${script_dirname}" "${@}"

--- a/images/devtools-terraform-v1beta1/tests/test_image.py
+++ b/images/devtools-terraform-v1beta1/tests/test_image.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import glob
 import os
 from pathlib import Path, PurePath
 import logging
@@ -6,7 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Iterator, Optional, TypeVar, Union
+from typing import Iterator, Optional, TypeVar, Union, Generator
 
 import pytest
 from pytest import CaptureFixture
@@ -15,6 +16,7 @@ TEST_DIR = Path(__file__).parent.absolute()
 PROTYPE_DIR = TEST_DIR / "prototype"
 
 RAPID_TEST = len(os.environ.get("RAPID_TEST", "")) > 0
+KEEP_TMP = len(os.environ.get("KEEP_TMP", "")) > 0
 
 PathLike = Union[PurePath, str]
 PathLikeT = TypeVar("PathLikeT", bound=PathLike)
@@ -31,26 +33,32 @@ def ctx_chdir(newdir: PathLikeT) -> Iterator[PathLikeT]:
 
 
 @contextmanager
-def ctx_prototype(tmp_path: Path, dottf_dir: Optional[Path]) -> Iterator[Path]:
+def ctx_prototype(
+    tmp_path: Path, dottf_dir: Optional[Path]
+) -> Generator[Path, None, None]:
     logging.debug("RAPID_TEST = %s", RAPID_TEST)
     workdir = tmp_path / "base"
     logging.info("workdir = %s, dottf_dir = %s", workdir, dottf_dir)
     shutil.copytree(
         PROTYPE_DIR,
         workdir,
-        ignore=shutil.ignore_patterns(".terraform", ".terraform.lock.hcl") if not RAPID_TEST else None,
+        ignore=shutil.ignore_patterns(".terraform", ".terraform.lock.hcl")
+        if not RAPID_TEST
+        else None,
     )
     if not RAPID_TEST:
         assert dottf_dir is not None
         shutil.copytree(dottf_dir, workdir / ".terraform")
-        shutil.copy2(dottf_dir.parent / ".terraform.lock.hcl", workdir / ".terraform.lock.hcl")
+        shutil.copy2(
+            dottf_dir.parent / ".terraform.lock.hcl", workdir / ".terraform.lock.hcl"
+        )
 
     with ctx_chdir(workdir):
         yield workdir
 
 
-@pytest.fixture(scope="module")
-def dottf_dir() -> Iterator[Optional[Path]]:
+@contextmanager
+def ctx_dottf_dir() -> Generator[Optional[Path], None, None]:
     logging.debug("RAPID_TEST = %s", RAPID_TEST)
     if RAPID_TEST:
         with ctx_chdir(PROTYPE_DIR):
@@ -63,7 +71,6 @@ def dottf_dir() -> Iterator[Optional[Path]]:
             yield tfdir
     else:
         _tmp_path = tempfile.mkdtemp("dottf_dir")
-        # _tmp_path = TemporaryDirectory("dottf_dir", ignore_cleanup_errors=True)
         tmp_path = Path(_tmp_path)
         try:
             workdir = tmp_path / "terraform_dir"
@@ -81,17 +88,143 @@ def dottf_dir() -> Iterator[Optional[Path]]:
                 logging.debug("tfdir = %s", tfdir)
             yield tfdir
         finally:
+            if KEEP_TMP:
+                return
             try:
                 shutil.rmtree(tmp_path, ignore_errors=True)
             except Exception:
                 logging.warning("failed to rmtree %s", tmp_path, exc_info=True)
 
 
-def test_prototype_ok(tmp_path: Path, dottf_dir: Optional[Path]) -> None:
+@pytest.fixture(scope="module")
+def dottf_dir() -> Iterator[Optional[Path]]:
+    with ctx_dottf_dir() as path:
+        yield path
+
+
+def test_prototype_ok(
+    tmp_path: Path, dottf_dir: Optional[Path], capfd: CaptureFixture[str]
+) -> None:
     with ctx_prototype(tmp_path, dottf_dir):
+        subprocess.run("id".split(" "), check=True)
         subprocess.run("pwd".split(" "), check=True)
         subprocess.run("find .".split(" "), check=True)
         subprocess.run("docker-compose run --rm devtools".split(" "), check=True)
+
+        captured = capfd.readouterr()
+        with capfd.disabled():
+            sys.stdout.write("captured.out:\n")
+            sys.stdout.write(captured.out)
+            sys.stderr.write("captured.err:\n")
+            sys.stderr.write(captured.err)
+        out_lines = captured.out.splitlines()
+        assert sum("No problems detected" in line for line in out_lines) == 2
+        assert sum("tfsec" in line for line in out_lines) == 2
+        assert sum("tflint" in line for line in out_lines) == 2
+
+
+def test_prototype_ok_no_module(
+    tmp_path: Path, dottf_dir: Optional[Path], capfd: CaptureFixture[str]
+) -> None:
+    with ctx_prototype(tmp_path, dottf_dir) as workdir:
+
+        shutil.rmtree(workdir / "eg_module", ignore_errors=False)
+        os.remove(workdir / "use_eg_module.tf")
+
+        subprocess.run("pwd".split(" "), check=True)
+        subprocess.run("find .".split(" "), check=True)
+        subprocess.run("docker-compose run --rm devtools".split(" "), check=True)
+
+        captured = capfd.readouterr()
+        with capfd.disabled():
+            sys.stdout.write("captured.out:\n")
+            sys.stdout.write(captured.out)
+            sys.stderr.write("captured.err:\n")
+            sys.stderr.write(captured.err)
+        out_lines = captured.out.splitlines()
+        assert sum("No problems detected" in line for line in out_lines) == 1
+        assert sum("tfsec" in line for line in out_lines) == 1
+        assert sum("tflint" in line for line in out_lines) == 1
+
+
+def test_prototype_reinit(
+    tmp_path: Path, dottf_dir: Optional[Path], capfd: CaptureFixture[str]
+) -> None:
+    with ctx_prototype(tmp_path, dottf_dir):
+        subprocess.run(
+            "docker-compose run --rm devtools validate".split(" "), check=True
+        )
+
+        subprocess.run(
+            "docker-compose run --rm devtools terraform-reinit".split(" "), check=True
+        )
+
+        subprocess.run(
+            "docker-compose run --rm devtools validate".split(" "), check=True
+        )
+
+        captured = capfd.readouterr()
+        with capfd.disabled():
+            sys.stdout.write("captured.out:\n")
+            sys.stdout.write(captured.out)
+            sys.stderr.write("captured.err:\n")
+            sys.stderr.write(captured.err)
+        out_lines = captured.out.splitlines()
+        assert sum("No problems detected" in line for line in out_lines) == 4
+        assert sum("tfsec" in line for line in out_lines) == 4
+        assert sum("tflint" in line for line in out_lines) == 4
+
+
+def test_prototype_env_vars(
+    tmp_path: Path, dottf_dir: Optional[Path], capfd: CaptureFixture[str]
+) -> None:
+    with ctx_prototype(tmp_path, dottf_dir) as workdir:
+
+        subprocess.run(
+            "docker-compose run --rm devtools validate TFDIRS=".split(" "), check=True
+        )
+
+        captured = capfd.readouterr()
+        with capfd.disabled():
+            sys.stdout.write("captured.out:\n")
+            sys.stdout.write(captured.out)
+            sys.stderr.write("captured.err:\n")
+            sys.stderr.write(captured.err)
+        out_lines = captured.out.splitlines()
+        assert sum("No problems detected" in line for line in out_lines) == 0
+        assert sum("tfsec" in line for line in out_lines) == 0
+        assert sum("tflint" in line for line in out_lines) == 0
+
+        (workdir / "blank").mkdir()
+        subprocess.run(
+            "docker-compose run --rm -e TFDIRS=blank devtools validate".split(" "),
+            check=True,
+        )
+
+        captured = capfd.readouterr()
+        with capfd.disabled():
+            sys.stdout.write("captured.out:\n")
+            sys.stdout.write(captured.out)
+            sys.stderr.write("captured.err:\n")
+            sys.stderr.write(captured.err)
+        out_lines = captured.out.splitlines()
+        assert sum("No problems detected" in line for line in out_lines) == 1
+        assert sum("tfsec" in line for line in out_lines) == 1
+        assert sum("tflint" in line for line in out_lines) == 1
+
+        subprocess.run(
+            [
+                *"docker-compose run --rm".split(" "),
+                "-e",
+                "TFDIRS_EXCLUDE=%/examples %/example %/eg_module",
+                "devtools",
+            ],
+            check=True,
+        )
+
+        assert sum("No problems detected" in line for line in out_lines) == 1
+        assert sum("tfsec" in line for line in out_lines) == 1
+        assert sum("tflint" in line for line in out_lines) == 1
 
 
 def test_prototype_fail_fmt(
@@ -186,3 +319,34 @@ resource "google_project_iam_binding" "iam_binding" {
             sys.stderr.write("captured.err:\n")
             sys.stderr.write(captured.err)
         assert "first.last@example.com is an invalid member format" in captured.out
+
+
+def test_prototype_fallback(
+    tmp_path: Path, dottf_dir: Optional[Path], capfd: CaptureFixture[str]
+) -> None:
+    with ctx_prototype(tmp_path, dottf_dir) as workdir:
+
+        for file in [*glob.glob("*"), *glob.glob(".*")]:
+            file_path = workdir / file
+            if file.endswith("docker-compose.yaml"):
+                continue
+            logging.debug("removing %s", file)
+            if file_path.is_dir():
+                shutil.rmtree(workdir / file, ignore_errors=False)
+            else:
+                os.remove(file)
+
+        subprocess.run(
+            "docker-compose run --rm devtools validate".split(" "), check=True
+        )
+
+        captured = capfd.readouterr()
+        with capfd.disabled():
+            sys.stdout.write("captured.out:\n")
+            sys.stdout.write(captured.out)
+            sys.stderr.write("captured.err:\n")
+            sys.stderr.write(captured.err)
+        out_lines = captured.out.splitlines()
+        assert sum("No problems detected" in line for line in out_lines) == 1
+        assert sum("tfsec" in line for line in out_lines) == 1
+        assert sum("tflint" in line for line in out_lines) == 1

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 # Kept as seperate config file as some plugins don't support pyproject.toml
 # (e.g pydantic.mypy)
 # https://mypy.readthedocs.io/en/stable/config_file.html
-python_version = 3.6
+python_version = 3.10
 strict = True
 warn_unreachable = True
 warn_unused_configs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ mypy = "^0.942"
 profile = "black"
 
 [tool.pytest.ini_options]
-addopts = ["--capture=no"]
+addopts = ["--capture=no", "--tb=native"]
 # https://docs.pytest.org/en/stable/customize.html
 # https://docs.pytest.org/en/stable/reference.html#configuration-options
 log_cli = true


### PR DESCRIPTION
Simplify terraform detect and fallback to current directory

The terraform directory detection was trying to be a bit too clever and
ended up missing a bunch of things. This simplifies terraform detection
by just checking for all directories that contain *.tf files, and if
none is found falling back to `.`.

Also:
- added a countermeasure for for potentially interactive tfswitch:
  - https://github.com/warrensbox/terraform-switcher/issues/165
- added TFDIRS_EXCLUDE and TFDIRS which users can use to control the
  directories that will be considered terraform directories.

Fixes https://github.com/coopnorge/engineering-docker-images/issues/60