### PR TITLE
tfswitch before initializing terraform in terraform image

### DIFF
--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -47,9 +47,11 @@ $(call dump_vars,tfdirs)
 terraform=terraform
 
 .terraform:
+	$(tfswitch)
 	$(terraform) init $(terraform_init_args)
 
 %/.terraform:
+	cd $(*) && $(tfswitch)
 	cd $(*) && $(terraform) init $(terraform_init_args)
 
 tfsec=tfsec


### PR DESCRIPTION
In regards to [this PR](https://github.com/coopnorge/cloud-projects/pull/392): the workflow seems to fail because it's running on an older version of Terraform compared to the workspace itself. `engineering-docker-images`'s TF image does use `terraform-switcher` to select the correct version of Terraform most of the time, [but seemingly not on initial terraform init](https://github.com/coopnorge/engineering-docker-images/blob/main/images/devtools-terraform-v1beta1/context/Makefile#L56), and from what I can tell, [that is the step that fails](https://github.com/coopnorge/cloud-projects/runs/6108948796?check_suite_focus=true).

As such, we need to invoke `terraform-switch` before the initialization steps as well.

@aucampia 
Is this a sensible way to solve this issue?