### PR TITLE
Add support for `.tfsec-ignore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@ Docker images are published to the following registries:
 
 Devtools images are intended for use in git repos to do validation and artifact building.
 
-- `devtools-golang-v1beta1`: Tools for golang.
+- `devtools-golang-v1beta1`: Development tools for golang.
 
   [Usage example](./images/devtools-golang-v1beta1/tests/prototype/).
 
-- `devtools-terraform-v1beta1`: Tools for terraform.
+- `devtools-terraform-v1beta1`: Development tools for terraform.
+
+  [README](./images/devtools-terraform-v1beta1/README.md).
 
   [Usage example](./images/devtools-terraform-v1beta1/tests/prototype/).
+
 
 #### Security Considerations for devtools
 

--- a/images/devtools-terraform-v1beta1/README.md
+++ b/images/devtools-terraform-v1beta1/README.md
@@ -1,0 +1,15 @@
+# Terraform Development Tools
+
+- `.tfsec-ignore` file: If this file is present in a directory with terraform
+  then tfsec will not be used on the directory.
+
+- `TFDIRS` environment variable: This is a space separated list of directories
+  for which terraform validation will be run.
+
+  Default: If this is not set it is auto-detected.
+
+- `TFDIRS_EXCLUDE` environment variable: This is a space separated list of GNU
+  make string pattens (which use `%` as wildcard) to exclude directories from
+  terraform validation.
+
+  Default: `%/examples %/example`

--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -75,7 +75,7 @@ validate-tf-$(1): | $(1)/.terraform
 	cd $(1) && $$(tfswitch)
 	cd $(1) && $$(terraform) fmt -check -recursive -diff
 	cd $(1) && $$(terraform) validate
-	$$(tfsec) $(1)
+	test -e "$(1)/.tfsec-ignore" || $$(tfsec) $(1)
 	$$(tflint) $(1)
 
 endef


### PR DESCRIPTION
This is so we can ignore https://github.com/coopnorge/cloud-projects/tree/main/teams
as tfsec is incredibly slow on this module.

More info can be seen in the README.