### PR TITLE
Make terraform devtools work with `.terraform` as a volume

### DIFF
--- a/images/devtools-terraform-v1beta1/context/Dockerfile
+++ b/images/devtools-terraform-v1beta1/context/Dockerfile
@@ -27,17 +27,6 @@ RUN \
     rm -vr /var/lib/apt/lists/* && \
     true
 
-
-
-COPY Makefile /usr/local/share/devtools-terraform/Makefile
-COPY maker /usr/local/bin/maker
-RUN \
-    ln -rs /usr/local/bin/maker /usr/local/bin/help && \
-    ln -rs /usr/local/bin/maker /usr/local/bin/validate && \
-    ln -rs /usr/local/bin/maker /usr/local/bin/validate-fix && \
-    ln -rs /usr/local/bin/maker /usr/local/bin/terraform-reinit && \
-    true
-
 VOLUME /srv/workspace
 WORKDIR /srv/workspace
 
@@ -52,9 +41,6 @@ COPY --from=docker-lock /prod/docker-lock /usr/local/bin/docker-lock
 
 COPY terraform-switcher_${tfswitcher_version}_checksums.txt /var/tmp/terraform-switcher_${tfswitcher_version}_checksums.txt
 
-# Setting TF_PLUGIN_CACHE_DIR makes things a lot faster but this somehow
-# causes weird permission issues.
-# ENV TF_PLUGIN_CACHE_DIR=/root/.cache/terraform.d/plugin-cache
 
 ARG terraform_versions="0.15.5 1.0.11 1.1.7"
 
@@ -77,5 +63,18 @@ RUN \
     # done; \
     true
 
+ENV TF_PLUGIN_CACHE_DIR=/root/.cache/terraform.d/plugin-cache
+
+
+COPY maker /usr/local/bin/maker
+RUN \
+    ln -rs /usr/local/bin/maker /usr/local/bin/help && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/validate && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/validate-fix && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/terraform-reinit && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/terraform-upgrade && \
+    true
+
+COPY Makefile /usr/local/share/devtools-terraform/Makefile
 
 CMD ["validate"]

--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -45,15 +45,21 @@ TFDIRS?=$(filter-out $(TFDIRS_EXCLUDE), \
 		| sed 's|/[^/]\{1,\}$$||g' \
 		| sort | uniq),.))
 
+TF_NO_PROVIDERS=
+
 $(info TFDIRS=$(TFDIRS))
 
 terraform=terraform
 
-.terraform:
+tf_plugin_cache_dir_target=$(if $(TF_PLUGIN_CACHE_DIR),$(TF_PLUGIN_CACHE_DIR)/,)
+
+$(call dump_vars,tf_plugin_cache_dir_target TF_PLUGIN_CACHE_DIR)
+
+.terraform .terraform/providers: | $(tf_plugin_cache_dir_target)
 	$(tfswitch)
 	$(terraform) init $(terraform_init_args)
 
-%/.terraform:
+%/.terraform %/.terraform/providers: | $(tf_plugin_cache_dir_target)
 	cd $(*) && $(tfswitch)
 	cd $(*) && $(terraform) init $(terraform_init_args)
 
@@ -65,15 +71,19 @@ define tfdir_targets
 
 tf-reinit: tf-reinit-$(1)
 .PHONY: tf-reinit-$(1)
-tf-reinit-$(1):
-	$(if $(TF_PLUGIN_CACHE_DIR),mkdir -vp $(TF_PLUGIN_CACHE_DIR),)
+tf-reinit-$(1): | $(tf_plugin_cache_dir_target)
+	cd $(1) && $$(tfswitch)
+	cd $(1) && $$(terraform) init
+
+tf-upgrade: tf-reinit-$(1)
+.PHONY: tf-reinit-$(1)
+tf-upgrade-$(1): | $(tf_plugin_cache_dir_target)
 	cd $(1) && $$(tfswitch)
 	cd $(1) && $$(terraform) init -upgrade
 
 validate: validate-tf-$(1)
 .PHONY: validate-tf-$(1)
-validate-tf-$(1): | $(1)/.terraform
-	$(if $(TF_PLUGIN_CACHE_DIR),mkdir -vp $(TF_PLUGIN_CACHE_DIR),)
+validate-tf-$(1): | $(1)/.terraform $(if $(TF_NO_PROVIDERS),,$(1)/.terraform/providers) $(tf_plugin_cache_dir_target)
 	cd $(1) && $$(tfswitch)
 	cd $(1) && $$(terraform) fmt -check -recursive -diff
 	cd $(1) && $$(terraform) validate
@@ -91,6 +101,12 @@ tf-reinit: ## Reintialize terraform
 
 .PHONY: terraform-reinit
 terraform-reinit: tf-reinit ## Reintialize terraform
+
+.PHONY: tf-upgrade
+tf-upgrade: ## Reintialize and upgrade terraform
+
+.PHONY: terraform-upgrade
+terraform-upgrade: tf-upgrade ## Reintialize and upgrade terraform
 
 $(foreach tfdir,$(TFDIRS),\
     $(eval $(call tfdir_targets,$(tfdir))))

--- a/images/devtools-terraform-v1beta1/context/docker-compose.yaml
+++ b/images/devtools-terraform-v1beta1/context/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  devtools:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /srv/workspace
+    volumes:
+      - ${WORKSPACE_DIR:-../tests/prototype}:/srv/workspace:z,cached
+      - xdg-cache-home:/root/.cache
+      - dot-terraform:/srv/workspace/.terraform
+volumes:
+  xdg-cache-home: {}
+  dot-terraform: {}

--- a/images/devtools-terraform-v1beta1/tests/README.md
+++ b/images/devtools-terraform-v1beta1/tests/README.md
@@ -3,10 +3,15 @@
 ```bash
 ## Run from repo root
 
-# build image
+# Build image.
 make IMAGE_NAMES=devtools-terraform-v1beta1 build
 
-# test image
+
+# Test image.
+IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/devtools-terraform-v1beta1:built \
+poetry run pytest images/devtools-terraform-v1beta1/tests
+
+# Rapid test image.
 IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/devtools-terraform-v1beta1:built \
 RAPID_TEST=1 \
 poetry run pytest images/devtools-terraform-v1beta1/tests

--- a/images/devtools-terraform-v1beta1/tests/prototype/.gitignore
+++ b/images/devtools-terraform-v1beta1/tests/prototype/.gitignore
@@ -1,3 +1,4 @@
+#### vimdiff <(curl --silent -L https://github.com/github/gitignore/raw/main/Terraform.gitignore) .gitignore
 # Local .terraform directories
 **/.terraform/*
 
@@ -10,8 +11,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json

--- a/images/devtools-terraform-v1beta1/tests/prototype/README.md
+++ b/images/devtools-terraform-v1beta1/tests/prototype/README.md
@@ -1,0 +1,16 @@
+# ...
+
+## Developing
+
+```bash
+# build images
+docker-compose build
+# see available targets
+docker-compose run --rm devtools help
+# validate
+docker-compose run --rm devtools validate
+# reinitalize terraform
+docker-compose run --rm devtools terraform-reinit
+# upgrade terraform modules/providers
+docker-compose run --rm devtools terraform-upgrade
+```

--- a/images/devtools-terraform-v1beta1/tests/prototype/docker-compose.yaml
+++ b/images/devtools-terraform-v1beta1/tests/prototype/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
     working_dir: /srv/workspace
     volumes:
       - .:/srv/workspace:z
-      - xdg-cache-home:/root/.cache
+      - ${_XDG_CACHE_DIR:-xdg-cache-home}:/root/.cache
+      - dot-terraform:/srv/workspace/.terraform
 volumes:
     xdg-cache-home: {}
+    dot-terraform: {}

--- a/images/devtools-terraform-v1beta1/tests/prototype/versions.tf
+++ b/images/devtools-terraform-v1beta1/tests/prototype/versions.tf
@@ -4,27 +4,6 @@ terraform {
   required_providers {
     null = {
       source = "hashicorp/null"
-      # version = "~> 3.1.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 4.4"
-    }
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 4.4"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.90"
-    }
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.13"
-    }
-    github = {
-      source  = "integrations/github"
-      version = "~> 4.19"
     }
   }
   required_version = "~> 1.0"


### PR DESCRIPTION
Stuff that goes into .terraform is arch and OS dependent so it is best
that this directory not be shared between host and guest, however if
you mounted a volume to `.terraform` then the Makefile did not do
terraform initialization.

This patch changes the Makefile to also check for
`.terraform/providers` and do initialization if it does not exist.
This should work in all cases where there at least one provider.

Also:
- Simplified the testing of the terraform image
- Enable terraform caching and test with and without caching
