### PR TITLE
Only run `terraform providers lock` in limited cases

### DIFF
--- a/images/devtools-terraform-v1beta1/README.md
+++ b/images/devtools-terraform-v1beta1/README.md
@@ -1,7 +1,7 @@
 # Terraform Development Tools
 
 - `terraform-reinit` target: This target will run `terraform init` in each
-  terraform directory followed by `terraform providers lock`.
+  terraform directory.
 
 - `terraform-upgrade` target: This target will run `terraform init -upgrade` in
   each terraform directory followed by `terraform providers lock`.
@@ -23,6 +23,11 @@
   terraform validation.
 
   Default: `%/examples %/example`
+
+- `TF_LOCK_PLATFORMS` environment variable: A space-sperarated list of
+  platforms that `terraform providers lock` should use.
+
+  Default: `linux_arm64 linux_amd64 darwin_amd64 darwin_arm64 windows_amd64`.
 
 ## Updating tfswitch version
 

--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -51,8 +51,8 @@ TF_NO_PROVIDERS=
 $(info TFDIRS=$(TFDIRS))
 
 terraform=terraform
-lock_platforms=linux_arm64 linux_amd64 darwin_amd64 darwin_arm64 windows_amd64
-terraform_providers_lock_args=$(foreach platform,$(lock_platforms), -platform=$(platform))
+TF_LOCK_PLATFORMS?=linux_arm64 linux_amd64 darwin_amd64 darwin_arm64 windows_amd64
+terraform_providers_lock_args=$(foreach platform,$(TF_LOCK_PLATFORMS), -platform=$(platform))
 
 tf_plugin_cache_dir_target=$(if $(TF_PLUGIN_CACHE_DIR),$(TF_PLUGIN_CACHE_DIR)/,)
 
@@ -65,7 +65,6 @@ $(call dump_vars,tf_plugin_cache_dir_target TF_PLUGIN_CACHE_DIR)
 %/.terraform %/.terraform/providers: | $(tf_plugin_cache_dir_target)
 	cd $(*) && $(tfswitch)
 	cd $(*) && $(terraform) init $(terraform_init_args)
-	cd $(*) && $(terraform) providers lock $(terraform_providers_lock_args)
 
 tfsec=tfsec
 tflint=tflint --enable-plugin=google --enable-plugin=azurerm $(if $(filter all commands,$(VERBOSE)),--loglevel=trace)
@@ -85,7 +84,6 @@ tf-reinit: tf-reinit-$(1)
 tf-reinit-$(1): | $(tf_plugin_cache_dir_target)
 	cd $(1) && $$(tfswitch)
 	cd $(1) && $$(terraform) init
-	cd $(1) && $$(terraform) providers lock $(terraform_providers_lock_args)
 
 tf-upgrade: tf-upgrade-$(1)
 .PHONY: tf-upgrade-$(1)

--- a/images/devtools-terraform-v1beta1/tests/README.md
+++ b/images/devtools-terraform-v1beta1/tests/README.md
@@ -11,6 +11,10 @@ make IMAGE_NAMES=devtools-terraform-v1beta1 build
 IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/devtools-terraform-v1beta1:built \
 poetry run pytest images/devtools-terraform-v1beta1/tests
 
+# Run specific test
+IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/devtools-terraform-v1beta1:built \
+poetry run pytest images/devtools-terraform-v1beta1/tests/test_image.py::test_runs
+
 # Rapid test image.
 IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/devtools-terraform-v1beta1:built \
 RAPID_TEST=1 \


### PR DESCRIPTION
Limit the cases where `terraform providers lock` will run to:
- When `terraform-upgrade` runs
- When `terraform-relock` runs

Previously it included:
- When there was no `.terraform/providers` dir
- When `terraform-reinit` runs

Also:
- Added `TF_LOCK_PLATFORMS` to control platforms to lock on, useful in
  cases where a specific provider does not support a specific platform.