### PR TITLE
Add benthos image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,3 +52,7 @@ updates:
     directory: "images/poetry-python3.10/context/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "images/benthos-v4/context/"
+    schedule:
+      interval: "daily"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ docker container should have anyway in order to operate as intended. This being
 said, care should be taken to not use these images with a docker daemon that is
 running as root.
 
+### Utilities
+
+- `benthos-v4`: Benthos version 4
+
+  [README](./images/benthos-v4/README.md).
+
+  - [`ghcr.io/coopnorge/engineering-docker-images/e0/benthos-v4`](https://github.com/coopnorge/engineering-docker-images/pkgs/container/engineering-docker-images%2Fe0%2Fbenthos-v4)
+  - [`europe-north1-docker.pkg.dev/engineering-production-af50/images/benthos-v4`](https://console.cloud.google.com/artifacts/docker/engineering-production-af50/europe-north1/images/benthos-v4)
+
 ## Developing
 
 ### Image Tests

--- a/images/benthos-v4/README.md
+++ b/images/benthos-v4/README.md
@@ -1,0 +1,7 @@
+# Latest benthos version 4.x
+
+This is a mirror of the latest version 4 of Benthos and is provided so that
+Benthos can be used with cloud run which needs the image to be on a Google
+registry.
+
+For more information see <https://v4.benthos.dev/>.

--- a/images/benthos-v4/context/Dockerfile
+++ b/images/benthos-v4/context/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.io/jeffail/benthos:4@sha256:e4d02271efa22bc2adb9696dfb4e0dd04564ee520dec400eb9f92f6c441d047b

--- a/images/benthos-v4/context/docker-compose.yaml
+++ b/images/benthos-v4/context/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  devtools:
+    build:
+      context: .
+      dockerfile: Dockerfile
+volumes: {}

--- a/images/benthos-v4/tests/README.md
+++ b/images/benthos-v4/tests/README.md
@@ -1,0 +1,11 @@
+
+
+```bash
+## Run from repo root
+
+# Build image.
+make IMAGE_NAMES=benthos-v4 build
+
+# Test image.
+poetry run pytest images/benthos-v4/tests
+```

--- a/images/benthos-v4/tests/run
+++ b/images/benthos-v4/tests/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+script_dirname="$( dirname -- "${0}" )"
+set -x
+exec poetry run pytest "${script_dirname}" "${@}"

--- a/images/benthos-v4/tests/test_image.py
+++ b/images/benthos-v4/tests/test_image.py
@@ -1,0 +1,71 @@
+import logging
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Iterable, List, Tuple, Union
+
+import docker
+import docker.errors
+import pytest
+from docker.models.images import Image
+
+TEST_DIR = Path(__file__).parent.absolute()
+IMAGE_CONTEXT_DIR = (TEST_DIR.parent / "context").absolute()
+
+
+@pytest.fixture(scope="session")
+def docker_client() -> docker.DockerClient:
+    return docker.DockerClient.from_env()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def build_image(
+    docker_client: docker.DockerClient,
+) -> Image:
+    image, _ = docker_client.images.build(
+        path=f"{IMAGE_CONTEXT_DIR}",
+        quiet=False,
+    )
+    logging.debug("image = %s, image.id = %s", image, image.id)
+    return image
+
+
+@pytest.mark.parametrize(
+    ["command", "success", "matchers"],
+    [
+        pytest.param(
+            "--version",
+            True,
+            [("Version: v4.", True)],
+            id="correct-version",
+        ),
+    ],
+)
+def test_runs(
+    docker_client: docker.DockerClient,
+    build_image: Image,
+    command: Union[List[str], str],
+    success: bool,
+    matchers: Iterable[Tuple[str, bool]],
+) -> None:
+    with ExitStack() as xstack:
+        if not success:
+            xstack.enter_context(pytest.raises(docker.errors.ContainerError))
+
+        output: bytes = docker_client.containers.run(
+            build_image.id,
+            command=command,
+            remove=True,
+        )
+
+        logging.debug("output = %s", output)
+        output_str = output.decode()
+
+        for match_string, match_positive in matchers:
+            if match_positive:
+                assert (
+                    match_string in output_str
+                ), f"did not find {match_string} in output ...\n{output_str}"
+            else:
+                assert (
+                    match_string not in output_str
+                ), f"found {match_string} in output\n{output_str}"

--- a/images/poetry-python3.10/tests/README.md
+++ b/images/poetry-python3.10/tests/README.md
@@ -1,0 +1,16 @@
+
+
+```bash
+## Run from repo root
+
+# Build image.
+make IMAGE_NAMES=poetry-python3.10 build
+
+# Test image.
+IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/poetry-python3.10:built \
+poetry run pytest images/poetry-python3.10/tests
+
+# Run specific test
+IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/poetry-python3.10:built \
+poetry run pytest images/poetry-python3.10/tests/test_image.py::test_runs
+```

--- a/images/poetry-python3.10/tests/test_image.py
+++ b/images/poetry-python3.10/tests/test_image.py
@@ -1,6 +1,6 @@
-import docker  # type: ignore[import]
+import docker
 import pytest
-from docker.models.images import Image  # type: ignore[import]
+from docker.models.images import Image
 
 
 @pytest.fixture(scope="session")

--- a/images/poetry-python3.8/tests/test_image.py
+++ b/images/poetry-python3.8/tests/test_image.py
@@ -1,6 +1,6 @@
-import docker  # type: ignore[import]
+import docker
 import pytest
-from docker.models.images import Image  # type: ignore[import]
+from docker.models.images import Image
 
 
 @pytest.fixture(scope="session")

--- a/images/poetry-python3.9/tests/test_image.py
+++ b/images/poetry-python3.9/tests/test_image.py
@@ -1,6 +1,6 @@
-import docker  # type: ignore[import]
+import docker
 import pytest
-from docker.models.images import Image  # type: ignore[import]
+from docker.models.images import Image
 
 
 @pytest.fixture(scope="session")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ explicit_package_bases = true
 namespace_packages = true
 mypy_path = "images"
 
+[[tool.mypy.overrides]]
+module = "docker.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 addopts = ["--capture=no", "--tb=native"]
 # https://docs.pytest.org/en/stable/customize.html


### PR DESCRIPTION
The image is a verbatim copy.

This is so that benthos is available on a google registry
where it can easily be used with Cloud Run.
