### PR TITLE
Revert "Bump library/python from 3.10.5 to 3.11.0b5 (#230)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/safewaters/docker-lock:0.8.10@sha256:e87cfa64db3ceb8e5d14ec41136b068e2335fdcdfbb890fa20dd091e82735d04 as docker-lock
 FROM docker.io/hadolint/hadolint:v2.10.0@sha256:93f0afd12c3be5d732227c0226dd8e7bb84f79319a773d7f8519e55f958ba415 as hadolint
 FROM docker.io/goodwithtech/dockle:v0.4.6@sha256:534ecfe2204403e1b563d61b255ddd4762b20c9d72ce7af239fb1135be6c9569 as dockle
-FROM docker.io/library/python:3.11.0b5@sha256:3bef58e5e0a2a5306a197508d3d8d31943095f91cbe141f68df9a15d698817d7 as python
+FROM docker.io/library/python:3.10.5@sha256:2f8af0b0adb15605c8015bd9015b1833a517757591cdf0c60604271a7664e8af as python
 
 FROM python as devtools
 


### PR DESCRIPTION
This reverts commit 23751fc40b42072642dbf3d1844747153e12d80e.

Reverting as it is a beta
