### PR TITLE
Use `startsWith` for `poetry-python3.*` images.

### DIFF
--- a/images/poetry-python3.10/tests/test_image.py
+++ b/images/poetry-python3.10/tests/test_image.py
@@ -21,12 +21,12 @@ def build_image(
 
 @pytest.fixture(scope="session")
 def expected_poetry_version() -> bytes:
-    return b"Poetry version 1.1.14\n"
+    return b"Poetry version 1.1"
 
 
 @pytest.fixture(scope="session")
 def expected_python_version() -> bytes:
-    return b"Python 3.10.5\n"
+    return b"Python 3.10"
 
 
 def test_image_should_return_a_correct_python_version(
@@ -40,10 +40,10 @@ def test_image_should_return_a_correct_python_version(
         command="poetry --version",
         remove=True,
     )
-    assert actual_poetry_version == expected_poetry_version
+    assert actual_poetry_version.startswith(expected_poetry_version)
     actual_python_version = docker_client.containers.run(
         build_image.id,
         command="python --version",
         remove=True,
     )
-    assert actual_python_version == expected_python_version
+    assert actual_python_version.startswith(expected_python_version)

--- a/images/poetry-python3.8/tests/test_image.py
+++ b/images/poetry-python3.8/tests/test_image.py
@@ -21,12 +21,12 @@ def build_image(
 
 @pytest.fixture(scope="session")
 def expected_poetry_version() -> bytes:
-    return b"Poetry version 1.1.14\n"
+    return b"Poetry version 1.1"
 
 
 @pytest.fixture(scope="session")
 def expected_python_version() -> bytes:
-    return b"Python 3.8.13\n"
+    return b"Python 3.8"
 
 
 def test_image_should_return_a_correct_python_version(
@@ -40,10 +40,10 @@ def test_image_should_return_a_correct_python_version(
         command="poetry --version",
         remove=True,
     )
-    assert actual_poetry_version == expected_poetry_version
+    assert actual_poetry_version.startswith(expected_poetry_version)
     actual_python_version = docker_client.containers.run(
         build_image.id,
         command="python --version",
         remove=True,
     )
-    assert actual_python_version == expected_python_version
+    assert actual_python_version.startswith(expected_python_version)

--- a/images/poetry-python3.9/tests/test_image.py
+++ b/images/poetry-python3.9/tests/test_image.py
@@ -21,12 +21,12 @@ def build_image(
 
 @pytest.fixture(scope="session")
 def expected_poetry_version() -> bytes:
-    return b"Poetry version 1.1.14\n"
+    return b"Poetry version 1.1"
 
 
 @pytest.fixture(scope="session")
 def expected_python_version() -> bytes:
-    return b"Python 3.9.13\n"
+    return b"Python 3.9"
 
 
 def test_image_should_return_a_correct_python_version(
@@ -40,10 +40,10 @@ def test_image_should_return_a_correct_python_version(
         command="poetry --version",
         remove=True,
     )
-    assert actual_poetry_version == expected_poetry_version
+    assert actual_poetry_version.startswith(expected_poetry_version)
     actual_python_version = docker_client.containers.run(
         build_image.id,
         command="python --version",
         remove=True,
     )
-    assert actual_python_version == expected_python_version
+    assert actual_python_version.startswith(expected_python_version)


### PR DESCRIPTION
So, we can merge Dependabot PRs if the update is minor.