### PR TITLE
Read Site name from catalog-info.yaml

### DIFF
--- a/images/techdocs/.gitignore
+++ b/images/techdocs/.gitignore
@@ -302,4 +302,6 @@ cython_debug/
 
 # End of https://www.toptal.com/developers/gitignore/api/node,python
 
+
+tests/prototype/mkdocs.yml
 site/

--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -54,12 +54,15 @@ lint: ../markdownlint.yaml ## Check markdown syntax
 linguistics-check: ## Check spelling, grammer and other linguistics issues
 	vale $(MARKDOWN_FILES)
 
+SITE_NAME := $(shell  yq --no-doc '.metadata.title // .metadata.name' ./catalog-info.yaml)
+
+.PHONY: mkdocs.yml
+mkdocs.yml: /usr/local/share/techdocs/mkdocs.yml
+	cp /usr/local/share/techdocs/mkdocs.yml mkdocs.yml
+
 .PHONY: build
-build: ## Build the website
-	mv mkdocs.yml ..
-	yq '. *= load("../mkdocs.yml")' /usr/local/share/techdocs/mkdocs.yml > mkdocs.yml
-	export REPO_NAME=$(REPO_NAME) export REPO_URL=$(REPO_URL) && export EDIT_URL=$(EDIT_URL) && techdocs-cli generate --no-docker
-	mv ../mkdocs.yml .
+build: mkdocs.yml ## Build the website
+	export SITE_NAME=$(SITE_NAME) && export REPO_NAME=$(REPO_NAME) export REPO_URL=$(REPO_URL) && export EDIT_URL=$(EDIT_URL) && techdocs-cli generate --no-docker
 
 ENTITY := $(shell yq --no-doc '[.metadata.namespace // "default", .kind, .metadata.name] | join("/")' ./catalog-info.yaml)
 

--- a/images/techdocs/context/mkdocs.yml
+++ b/images/techdocs/context/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Baseline
+site_name: !ENV SITE_NAME
 repo_name: !ENV [REPO_NAME, null]
 repo_url: !ENV [REPO_URL, null]
 edit_url: !ENV [EDIT_URL, null]

--- a/images/techdocs/tests/prototype/mkdocs.yml
+++ b/images/techdocs/tests/prototype/mkdocs.yml
@@ -1,1 +1,0 @@
-site_name: Test Prototype


### PR DESCRIPTION
Reading the site name from `catalog-info.yaml` removes the need to
provide a `mkdocs.yml`.
