### PR TITLE
Add quotes around SITE_NAME in techdocs image

### DIFF
--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -51,7 +51,7 @@ lint: ../markdownlint.yaml ## Check markdown syntax
 	markdownlint --config=../markdownlint.yaml $(DOCS_DIR)
 
 .PHONY: linguistics-check
-linguistics-check: ## Check spelling, grammer and other linguistics issues
+linguistics-check: ## Check spelling, grammar and other linguistics issues
 	vale $(MARKDOWN_FILES)
 
 SITE_NAME := $(shell  yq --no-doc '.metadata.title // .metadata.name' ./catalog-info.yaml)
@@ -62,7 +62,7 @@ mkdocs.yml: /usr/local/share/techdocs/mkdocs.yml
 
 .PHONY: build
 build: mkdocs.yml ## Build the website
-	export SITE_NAME=$(SITE_NAME) && export REPO_NAME=$(REPO_NAME) export REPO_URL=$(REPO_URL) && export EDIT_URL=$(EDIT_URL) && techdocs-cli generate --no-docker
+	export SITE_NAME="$(SITE_NAME)" && export REPO_NAME=$(REPO_NAME) export REPO_URL=$(REPO_URL) && export EDIT_URL=$(EDIT_URL) && techdocs-cli generate --no-docker
 
 ENTITY := $(shell yq --no-doc '[.metadata.namespace // "default", .kind, .metadata.name] | join("/")' ./catalog-info.yaml)
 

--- a/images/techdocs/tests/prototype/catalog-info.yaml
+++ b/images/techdocs/tests/prototype/catalog-info.yaml
@@ -3,6 +3,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: test-prototype
+  title: Test Prototype
   description: This is a test protoype
   annotations:
     github.com/project-slug: example/test-prototype


### PR DESCRIPTION
Closes #456.

I don't think it's actually possible to test this change as the Python tests seem to test the image, and the change is in the `Makefile`. Regardless I added the `SITE_NAME` value to the test, as this is how the value should be presented by the Makefile.

This will be tested at least when the `storm-121` CI runs and picks up this new image.