### PR TITLE
Set unordered lint indent to 2

### DIFF
--- a/images/techdocs/context/markdownlint.yaml
+++ b/images/techdocs/context/markdownlint.yaml
@@ -2,7 +2,7 @@ default: true
 
 # MD007/ul-indent - Unordered list indentation
 MD007:
-  indent: 4  # This is what works in mkdocs
+  indent: 2  # This is what works in TechDocs
 
 MD033: false
 


### PR DESCRIPTION
TechDocs does not support 4 space indents for unordered lists, instead
we have to use 2 spaces.
