### PR TITLE
Add local preview to TechDocs image

### DIFF
--- a/images/techdocs/README.md
+++ b/images/techdocs/README.md
@@ -5,14 +5,48 @@ in Inventory.
 
 ## Usage
 
-### Running a development server
+The image is designed to run in a repository containing TechDocs.
 
-```bash
-docker run -v $(pwd):/content -p 3000:3000 ghcr.io/coopnorge/engineering-docker-images/e0/techdocs techdocs-cli serve --no-docker -v
+### Docker compose configuration
+
+Add a `docker-compose.yaml` file to the repository.
+
+```yaml
+---
+services:
+  techdocs:
+    build:
+      context: docker-compose
+      dockerfile: Dockerfile
+      target: techdocs
+    working_dir: /content
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-}
+      GCLOUD_PROJECT: ${GCLOUD_PROJECT:-}
+    volumes:
+      - .:/content
+      - ${XDG_CACHE_HOME:-xdg-cache-home}:/root/.cache
+      - $HOME/.config/gcloud:/root/.config/gcloud
+      - ${GOOGLE_APPLICATION_CREDENTIALS:-nothing}:${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/empty-GOOGLE_APPLICATION_CREDENTIALS}
+    ports:
+      - "127.0.0.1:3000:3000/tcp"
+      - "127.0.0.1:8000:8000/tcp"
+    command: serve
+volumes:
+  xdg-cache-home: { }
+  nothing: { }
 ```
 
-### Other targets
+### Running a preview site
 
 ```bash
-docker run -v $(pwd):/content ghcr.io/coopnorge/engineering-docker-images/e0/techdocs help
+docker compose up techdocs
+```
+
+Open your browser at http://localhost:3000/docs/default/component/local/
+
+###  List targets
+
+```bash
+docker compose run --rm techdocs help
 ```

--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -10,7 +10,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir /srv/workspace
 WORKDIR /srv/workspace
 
-RUN apt-get update \
+RUN apt-get clean \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
         lsb-release=11.1.0 \
         apt-transport-https=2.2.4 \
@@ -77,6 +78,7 @@ RUN \
     ln -rs /usr/local/bin/maker /usr/local/bin/lint && \
     ln -rs /usr/local/bin/maker /usr/local/bin/linguistics-check && \
     ln -rs /usr/local/bin/maker /usr/local/bin/build && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/serve && \
     ln -rs /usr/local/bin/maker /usr/local/bin/publish && \
     true
 

--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -70,6 +70,9 @@ build: mkdocs.yml ## Build the website
 
 ENTITY := $(shell yq --no-doc '[.metadata.namespace // "default", .kind, .metadata.name] | join("/")' ./catalog-info.yaml)
 
+serve: mkdocs.yml ## Run a preview site
+	export SITE_NAME="$(SITE_NAME)" && export REPO_NAME=$(REPO_NAME) export REPO_URL=$(REPO_URL) && export EDIT_URI=$(EDIT_URI) && techdocs-cli serve --no-docker
+
 .PHONY: publish
 publish: site ## Publish the website to the TechDocs Bucket
 	techdocs-cli publish --publisher-type googleGcs --storage-name $(TECHDOCS_BUCKET) --entity $(ENTITY)

--- a/images/techdocs/context/package-lock.json
+++ b/images/techdocs/context/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@techdocs/cli": "1.2.2",
+        "@techdocs/cli": "1.2.0",
         "markdownlint": "^0.26.2",
         "markdownlint-cli": "^0.32.2"
       }
@@ -1046,15 +1046,15 @@
       }
     },
     "node_modules/@techdocs/cli": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@techdocs/cli/-/cli-1.2.2.tgz",
-      "integrity": "sha512-7KV+raxGhPQu2JWKSdiRzxh1GRjBM1XmD3OZJ9vmRLvFEEpm29NVI7UDC2xd4FrtFLgHwiU51lFX0AvtLyeD9g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@techdocs/cli/-/cli-1.2.0.tgz",
+      "integrity": "sha512-JHOqRJUDGomlMzwkRHOzgLAws1vum4LH1t2sFpghXR8k2U0VU3OvjAJlXgybtjI6W8U5Q+JjoPWgCT/7GMl16Q==",
       "dependencies": {
-        "@backstage/backend-common": "^0.15.2",
-        "@backstage/catalog-model": "^1.1.2",
-        "@backstage/cli-common": "^0.1.10",
-        "@backstage/config": "^1.0.3",
-        "@backstage/plugin-techdocs-node": "^1.4.1",
+        "@backstage/backend-common": "^0.15.0",
+        "@backstage/catalog-model": "^1.1.0",
+        "@backstage/cli-common": "^0.1.9",
+        "@backstage/config": "^1.0.1",
+        "@backstage/plugin-techdocs-node": "^1.3.0",
         "@types/dockerode": "^3.3.0",
         "commander": "^9.1.0",
         "dockerode": "^3.3.1",
@@ -9495,15 +9495,15 @@
       "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g=="
     },
     "@techdocs/cli": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@techdocs/cli/-/cli-1.2.2.tgz",
-      "integrity": "sha512-7KV+raxGhPQu2JWKSdiRzxh1GRjBM1XmD3OZJ9vmRLvFEEpm29NVI7UDC2xd4FrtFLgHwiU51lFX0AvtLyeD9g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@techdocs/cli/-/cli-1.2.0.tgz",
+      "integrity": "sha512-JHOqRJUDGomlMzwkRHOzgLAws1vum4LH1t2sFpghXR8k2U0VU3OvjAJlXgybtjI6W8U5Q+JjoPWgCT/7GMl16Q==",
       "requires": {
-        "@backstage/backend-common": "^0.15.2",
-        "@backstage/catalog-model": "^1.1.2",
-        "@backstage/cli-common": "^0.1.10",
-        "@backstage/config": "^1.0.3",
-        "@backstage/plugin-techdocs-node": "^1.4.1",
+        "@backstage/backend-common": "^0.15.0",
+        "@backstage/catalog-model": "^1.1.0",
+        "@backstage/cli-common": "^0.1.9",
+        "@backstage/config": "^1.0.1",
+        "@backstage/plugin-techdocs-node": "^1.3.0",
         "@types/dockerode": "^3.3.0",
         "commander": "^9.1.0",
         "dockerode": "^3.3.1",

--- a/images/techdocs/context/package.json
+++ b/images/techdocs/context/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@techdocs/cli": "1.2.2",
+    "@techdocs/cli": "1.2.0",
     "markdownlint": "^0.26.2",
     "markdownlint-cli": "^0.32.2"
   }


### PR DESCRIPTION
Use `docker compose up techdocs` to run the TechDocs preview site. The
reason for this is that `docker compose run` cannot expose ports.

TechDocs is downgraded due to a bug in 1.2.1 and 1.2.2 that breaks the
preview site.

Closes: #465, closes: #468, closes: coopnorge/coop-playbook#834
