### PR TITLE
Unify the input to validate sub-targets

### DIFF
--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -8,7 +8,6 @@ docker_compose := $(docker) compose
 docker_compose_run := $(docker_compose) run --rm -T
 
 BASE_BRANCH := origin/main
-DOCS_DIR := docs/
 MARKDOWN_FILES := $(shell git diff --name-only --diff-filter=ACMRT $(BASE_BRANCH) | grep .md$$)
 
 .PHONY: help
@@ -52,7 +51,7 @@ validate: lint linguistics-check ## Validate the content
 
 .PHONY: lint
 lint: ../markdownlint.yaml ## Check markdown syntax
-	markdownlint --config=../markdownlint.yaml $(DOCS_DIR)
+	markdownlint --config=../markdownlint.yaml $(MARKDOWN_FILES)
 
 .PHONY: linguistics-check
 linguistics-check: ## Check spelling, grammar and other linguistics issues

--- a/images/techdocs/tests/test_image.py
+++ b/images/techdocs/tests/test_image.py
@@ -59,7 +59,7 @@ def test_lint(
 ) -> None:
     actual_output = docker_client.containers.run(
         build_image.id,
-        command="lint DOCS_DIR=docs/",
+        command="lint MARKDOWN_FILES=docs/",
         volumes=volumes,
         remove=True,
     )
@@ -90,11 +90,14 @@ def test_test_validate(
 ) -> None:
     actual_output = docker_client.containers.run(
         build_image.id,
-        command='validate DOCS_DIR="docs/" MARKDOWN_FILES="README.md docs/index.md"',
+        command='validate MARKDOWN_FILES="README.md docs/index.md"',
         volumes=volumes,
         remove=True,
     )
-    assert b"markdownlint --config=../markdownlint.yaml docs/\n" in actual_output
+    assert (
+        b"markdownlint --config=../markdownlint.yaml README.md docs/index.md\n"
+        in actual_output
+    )
     assert (
         b"vale README.md docs/index.md\n\xe2\x9c\x94 \x1b[31m0 errors\x1b[0m, \x1b[33m0 warnings\x1b[0m and \x1b[34m0 suggestions\x1b[0m in 2 files.\n"
         in actual_output


### PR DESCRIPTION
`lint` and `linguistics-check` now uses the same input `MARKDOWN_FILES`
to set the files to check. This reduces the cognitive load on the users
of the TechDocs image.
