### PR TITLE
Add validate-fix target for techdocs

### DIFF
--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -75,6 +75,8 @@ COPY maker /usr/local/bin/maker
 RUN \
     ln -rs /usr/local/bin/maker /usr/local/bin/help && \
     ln -rs /usr/local/bin/maker /usr/local/bin/validate && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/validate-fix && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/lint-fix && \
     ln -rs /usr/local/bin/maker /usr/local/bin/lint && \
     ln -rs /usr/local/bin/maker /usr/local/bin/linguistics-check && \
     ln -rs /usr/local/bin/maker /usr/local/bin/build && \

--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -41,6 +41,9 @@ package-lock.json: package.json ## Generate requirements-techdocs.txt
 .PHONY: validate
 validate: lint linguistics-check ## Validate the content
 
+.PHONY: validate-fix
+validate-fix: lint-fix ## Fix auto-fixable validation errors
+
 ../markdownlint.yaml:
 	if [ -s .markdownlint.yaml ]; then \
 	    yq '. *= load(".markdownlint.yaml")' /usr/local/share/techdocs/markdownlint.yaml > $@ ;\
@@ -51,6 +54,10 @@ validate: lint linguistics-check ## Validate the content
 .PHONY: lint
 lint: ../markdownlint.yaml ## Check markdown syntax
 	markdownlint --config=../markdownlint.yaml $(MARKDOWN_FILES)
+
+.PHONY: lint-fix
+lint-fix: ../markdownlint.yaml ## Fix auto-fixable markdownlint failures
+	markdownlint --fix --config=../markdownlint.yaml $(MARKDOWN_FILES)
 
 .PHONY: linguistics-check
 linguistics-check: ## Check spelling, grammar and other linguistics issues

--- a/images/techdocs/context/README.md
+++ b/images/techdocs/context/README.md
@@ -1,0 +1,15 @@
+This file contains instructions on using the `techdocs` image as you develop it.
+
+```bash
+# change into the image context directory
+cd ./images/techdocs/context/
+
+# build the image
+docker compose build self
+
+# run the default target
+docker compose run --rm self
+
+# get help
+docker compose run --rm self help
+```

--- a/images/techdocs/context/docker-compose.yaml
+++ b/images/techdocs/context/docker-compose.yaml
@@ -20,6 +20,14 @@ services:
       - .:/srv/workspace:z
       - ${XDG_CACHE_HOME:-xdg-cache-home}:/root/.cache
     working_dir: /srv/workspace
-
+  self:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: "techdocs-cli"
+    working_dir: /content
+    volumes:
+      - ${WORKSPACE_DIR:-../tests/prototype}:/content:z,cached
+      - ${XDG_CACHE_HOME:-xdg-cache-home}:/root/.cache
 volumes:
   xdg-cache-home: {}

--- a/images/techdocs/tests/README.md
+++ b/images/techdocs/tests/README.md
@@ -1,0 +1,16 @@
+## Techdocs tests
+
+```bash
+## Run commands from repo root
+
+# Build image.
+make IMAGE_NAMES=techdocs build
+
+# Test image.
+IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/techdocs:built \
+poetry run pytest images/techdocs/tests
+
+# Run specific test
+IMAGE_UNDER_TEST=ocreg.invalid/coopnorge/engineering/image/techdocs:built \
+poetry run pytest 'images/techdocs/tests/test_image.py::test_command_output'
+```


### PR DESCRIPTION
This is so that it is easier to fix auto-fixable validation errors.

We had this before for the playbook but sadly it was lost when we moved
to backstage.

- Fixes https://github.com/coopnorge/engineering-docker-images/issues/519

