### PR TITLE
Don't hardcode docker host

### DIFF
--- a/images/poetry-python3.10/tests/test_image.py
+++ b/images/poetry-python3.10/tests/test_image.py
@@ -5,7 +5,7 @@ from docker.models.images import Image
 
 @pytest.fixture(scope="session")
 def docker_client() -> docker.DockerClient:
-    return docker.DockerClient(base_url="unix:///var/run/docker.sock")
+    return docker.DockerClient.from_env()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/images/poetry-python3.11/tests/test_image.py
+++ b/images/poetry-python3.11/tests/test_image.py
@@ -5,7 +5,7 @@ from docker.models.images import Image
 
 @pytest.fixture(scope="session")
 def docker_client() -> docker.DockerClient:
-    return docker.DockerClient(base_url="unix:///var/run/docker.sock")
+    return docker.DockerClient.from_env()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/images/poetry-python3.8/tests/test_image.py
+++ b/images/poetry-python3.8/tests/test_image.py
@@ -5,7 +5,7 @@ from docker.models.images import Image
 
 @pytest.fixture(scope="session")
 def docker_client() -> docker.DockerClient:
-    return docker.DockerClient(base_url="unix:///var/run/docker.sock")
+    return docker.DockerClient.from_env()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/images/poetry-python3.9/tests/test_image.py
+++ b/images/poetry-python3.9/tests/test_image.py
@@ -5,7 +5,7 @@ from docker.models.images import Image
 
 @pytest.fixture(scope="session")
 def docker_client() -> docker.DockerClient:
-    return docker.DockerClient(base_url="unix:///var/run/docker.sock")
+    return docker.DockerClient.from_env()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/images/techdocs/tests/test_image.py
+++ b/images/techdocs/tests/test_image.py
@@ -8,7 +8,7 @@ from docker.models.images import Image
 
 @pytest.fixture(scope="session")
 def docker_client() -> docker.DockerClient:
-    return docker.DockerClient(base_url="unix:///var/run/docker.sock")
+    return docker.DockerClient.from_env()
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
Hardcoding docker host breaks things for people who use rootless docker
on Linux.

- Fixes https://github.com/coopnorge/engineering-docker-images/issues/520
