### PR TITLE
Add support for downloading vale packages

### DIFF
--- a/images/techdocs/.gitignore
+++ b/images/techdocs/.gitignore
@@ -305,3 +305,4 @@ cython_debug/
 
 tests/prototype/mkdocs.yml
 site/
+.vale

--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -74,6 +74,7 @@ RUN pip install \
 COPY maker /usr/local/bin/maker
 RUN \
     ln -rs /usr/local/bin/maker /usr/local/bin/help && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/vale-sync && \
     ln -rs /usr/local/bin/maker /usr/local/bin/validate && \
     ln -rs /usr/local/bin/maker /usr/local/bin/validate-fix && \
     ln -rs /usr/local/bin/maker /usr/local/bin/lint-fix && \

--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -59,8 +59,12 @@ lint: ../markdownlint.yaml ## Check markdown syntax
 lint-fix: ../markdownlint.yaml ## Fix auto-fixable markdownlint failures
 	markdownlint --fix --config=../markdownlint.yaml $(MARKDOWN_FILES)
 
+.PHONY: vale-sync
+vale-sync:
+	vale sync
+
 .PHONY: linguistics-check
-linguistics-check: ## Check spelling, grammar and other linguistics issues
+linguistics-check: vale-sync ## Check spelling, grammar and other linguistics issues
 	vale $(MARKDOWN_FILES)
 
 SITE_NAME := $(shell  yq --no-doc '.metadata.title // .metadata.name' ./catalog-info.yaml)

--- a/images/techdocs/tests/prototype/.vale.ini
+++ b/images/techdocs/tests/prototype/.vale.ini
@@ -1,3 +1,7 @@
+StylesPath = .vale/
+
+Packages = Google
+
 [*.md]
 TokenIgnores = [\w][\w.]*@[\w*][\w.]*[\w]
 BasedOnStyles = Vale

--- a/images/techdocs/tests/test_image.py
+++ b/images/techdocs/tests/test_image.py
@@ -69,6 +69,20 @@ def test_lint(
     assert b"markdownlint --config=../markdownlint.yaml docs/\n" in actual_output
 
 
+def test_vale_sync(
+    docker_client: docker.DockerClient,
+    build_image: Image,
+    volumes: dict[str, dict[str, str]],
+) -> None:
+    actual_output = docker_client.containers.run(
+        build_image.id,
+        command="vale-sync",
+        volumes=volumes,
+        remove=True,
+    )
+    assert b"vale sync" in actual_output
+
+
 def test_linguistics_check(
     docker_client: docker.DockerClient,
     build_image: Image,
@@ -81,8 +95,8 @@ def test_linguistics_check(
         remove=True,
     )
     assert (
-        actual_output
-        == b"vale README.md docs/index.md\n\xe2\x9c\x94 \x1b[31m0 errors\x1b[0m, \x1b[33m0 warnings\x1b[0m and \x1b[34m0 suggestions\x1b[0m in 2 files.\n"
+        b"vale README.md docs/index.md\n\xe2\x9c\x94 \x1b[31m0 errors\x1b[0m, \x1b[33m0 warnings\x1b[0m and \x1b[34m0 suggestions\x1b[0m in 2 files.\n"
+        in actual_output
     )
 
 


### PR DESCRIPTION
To enable usage of our Coop Vale Package we need to be able to download
the package before running vale.
