### PR TITLE
Add socat and busybox to the techdocs image

### DIFF
--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get clean \
     && apt-get install --no-install-recommends -y \
         lsb-release=11.1.0 \
         apt-transport-https=2.2.4 \
+        busybox=1:1.30.1-6+b3 \
+        socat=1.7.4.1-3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The live preview of techdocs listens on `127.0.0.1`, and if this is inside a docker container it is not possible to get to it via port bindings [[ref](https://stackoverflow.com/a/52518929)].

`socat` can be used to re-expose the stuff listening on `127.0.0.1`.

I added busybox mainly because it provides a bunch of useful tools that can be used to debug various issues with the image.