### PR TITLE
Disable version pinning for hadolint for tzdata

### DIFF
--- a/images/devtools-golang-v1beta1/context/Dockerfile.app
+++ b/images/devtools-golang-v1beta1/context/Dockerfile.app
@@ -7,6 +7,7 @@ FROM docker.io/library/alpine:3@sha256:f271e74b17ced29b915d351685fd4644785c6d155
 
 FROM alpine AS runtime
 
+# hadolint disable=DL3018
 RUN \
     apk --no-cache update &&\
     apk --no-cache add \


### PR DESCRIPTION
When building a container image using the devtools-golang-v1beta1
hadolint complains about unpinned versions. If we do not want to pin the
version of this dependency we need to disable the rule for this specific
line.

Closes: #641
