### PR TITLE
Ignore version pinning for hadolint for tzdata

### DIFF
--- a/images/devtools-golang-v1beta1/context/Dockerfile.app
+++ b/images/devtools-golang-v1beta1/context/Dockerfile.app
@@ -7,7 +7,7 @@ FROM docker.io/library/alpine:3@sha256:f271e74b17ced29b915d351685fd4644785c6d155
 
 FROM alpine AS runtime
 
-# hadolint disable=DL3018
+# hadolint ignore=DL3018
 RUN \
     apk --no-cache update &&\
     apk --no-cache add \


### PR DESCRIPTION
RTFM... using old issues as docs is not good, test would be good to.

`ignore` is the right way to turn off a rule, not `disable`.

Closes: #641
