### PR TITLE
Output the OCI metedata to a JSON file.

### DIFF
--- a/images/devtools-golang-v1beta1/context/Makefile
+++ b/images/devtools-golang-v1beta1/context/Makefile
@@ -67,6 +67,7 @@ APP_DOCKERFILE?=build/package/Dockerfile
 BUILD_OCI?=$(if $(wildcard $(APP_DOCKERFILE)),true,false)
 XDG_CACHE_HOME?=$(HOME)/.cache
 ENABLE_BUF?=$(if $(wildcard buf.work.yaml),true,false)
+OCI_METADATA?=oci-metadata.json
 
 # setting this so that it is more likely things will work on MacOS and Linux
 export POSIXLY_CORRECT:=1
@@ -335,6 +336,7 @@ oci-build-stage-%: $(APP_DOCKERFILE) oci-dockerfile-validate | $(oci_images_dir)
 		--opt filename=$(notdir $(<)) \
 		--local context=$(oci_context_dir) \
 		--local dockerfile=$(dir $(<)) \
+		--metadata-file $(OCI_METADATA) \
 		--output $(oci_build_stage_output) \
     	$(buildctl_extra_args) \
 		$(foreach oci_build_arg,$(oci_build_args),--opt build-arg:$(oci_build_arg)) \


### PR DESCRIPTION
To easily be able to pin an OCI to a specific version we need the output
from the OCI build.

For more information see: https://github.com/moby/buildkit#metadata
