### PR TITLE
Remove deprecated linters

### DIFF
--- a/images/devtools-golang-v1beta1/context/.golangci.yml
+++ b/images/devtools-golang-v1beta1/context/.golangci.yml
@@ -3,7 +3,6 @@ linters:
   disable-all: true
   enable:
   - contextcheck
-  - deadcode
   - errcheck
   - gofmt
   - goimports
@@ -13,10 +12,8 @@ linters:
   - misspell
   - revive
   - staticcheck
-  - structcheck
   - typecheck
   - unused
-  - varcheck
   - whitespace
 issues:
   exclude-use-default: false

--- a/images/devtools-golang-v1beta1/tests/test_image.py
+++ b/images/devtools-golang-v1beta1/tests/test_image.py
@@ -190,7 +190,12 @@ func UnusedFunc() int {
 """
                 )
             ),
-            [("`UnusedFunc` is unused", True)],
+            [
+                (
+                    "exported: exported function UnusedFunc should have comment or be unexported (revive)",
+                    True,
+                )
+            ],
             id="validate-unchecked-return",
         ),
         pytest.param(


### PR DESCRIPTION
`deadcode`, `varcheck` and `structcheck` are deprecated and replaced by
`unused`.

Here is the output for the build logs

```console
level=warning msg="[runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
level=warning msg="[runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
level=warning msg="[runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
```
