### PR TITLE
Bump golangci/golangci-lint from v1.50.0-alpine to v1.51.0-alpine in /images/devtools-golang-v1beta1/context

### DIFF
--- a/docker-lock.json
+++ b/docker-lock.json
@@ -153,8 +153,8 @@
 			},
 			{
 				"name": "golangci/golangci-lint",
-				"tag": "v1.48.0-alpine",
-				"digest": "e9ce901b7974d641d6288b070fc619d199a823d0f696563fec8be90f19789b57"
+				"tag": "v1.51.0-alpine",
+				"digest": "a287ca89d0dbbfbbfb14996e7be3ac3f10f034c7fb4f560f845f623083d7067d"
 			},
 			{
 				"name": "docker.io/mikefarah/yq",

--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/safewaters/docker-lock:latest@sha256:432d90ddc2891f4845241adc63e5eef2dd1486fa14ea7882433cbd3f8ed64622 AS docker-lock
-FROM golangci/golangci-lint:v1.50-alpine@sha256:a392d4e44049a444a927878792dae9534075ec57880e0657647ce818bd8278c2 AS golangci-lint
+FROM golangci/golangci-lint:v1.51-alpine@sha256:a287ca89d0dbbfbbfb14996e7be3ac3f10f034c7fb4f560f845f623083d7067d AS golangci-lint
 FROM docker.io/fullstorydev/grpcurl:v1.8.7@sha256:d42ef512419560776bee5bb51e338a1734a0edb99f450b6d98fd98bcc93796f3 AS grpcurl
 FROM docker.io/mikefarah/yq:4@sha256:d4e1d060e248bdc3ac9e0fccfb4209e24ff42ed3d39beab33d3c3a19480b14fd AS yq
 FROM docker.io/hadolint/hadolint:v2.12.0@sha256:30a8fd2e785ab6176eed53f74769e04f125afb2f74a6c52aef7d463583b6d45e AS hadolint


### PR DESCRIPTION
Dependabot is stuck on this dependency, bumping manually
