### PR TITLE
Bump bufbuild/buf from 1.12.0 to 1.12.0 in /images/devtools-golang-v1beta1/context

### DIFF
--- a/docker-lock.json
+++ b/docker-lock.json
@@ -183,8 +183,8 @@
 			},
 			{
 				"name": "docker.io/bufbuild/buf",
-				"tag": "1.9.0",
-				"digest": "24abb6b50fbdda65974f1b127b89e66c9d74c9e1415c4536a4755808ed679456"
+				"tag": "1.15.0",
+				"digest": "d3a2fd8745fdc5545acc1d0d4211a7d5d991916ce8321fcf4612b6589a880373"
 			},
 			{
 				"name": "docker.io/library/golang",

--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -6,7 +6,7 @@ FROM docker.io/hadolint/hadolint:v2.12.0@sha256:30a8fd2e785ab6176eed53f74769e04f
 FROM --platform=linux/amd64 docker.io/goodwithtech/dockle:v0.4.11@sha256:79ef341552b293f13e7d915747b325c19f6ac47ed4d7bff2bff909fdd493acd7 AS dockle
 FROM docker.io/moby/buildkit:v0.10.6-rootless@sha256:df14db059c966a3329b223f32bb6de6f91711c8f96090e71036fffa983d76eed AS buildkit
 FROM gcr.io/go-containerregistry/crane:v0.13.0@sha256:9ddb050949d8e9a37a96d7f9762095c332e015246200dc2984481f1771602fba AS crane
-FROM docker.io/bufbuild/buf:1.12.0@sha256:da02042a9fa7a28ccd7c6f55c8130a5fb5403fdac47cd4c6f96525310e37e8fc AS buf
+FROM docker.io/bufbuild/buf:1.15.0@sha256:d3a2fd8745fdc5545acc1d0d4211a7d5d991916ce8321fcf4612b6589a880373 AS buf
 FROM docker.io/library/golang:1.19.5-bullseye@sha256:c3feb4bc19853836e788b21051b76b813a30457b3f77058991d3e170af0afa65 AS base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Dependabot is stuck on this dependency, bumping manually
