### PR TITLE
Bump moby/buildkit from buildkit:v0.10.6-rootless to v0.11.3-rootless in /images/devtools-golang-v1beta1/context

### DIFF
--- a/docker-lock.json
+++ b/docker-lock.json
@@ -173,8 +173,8 @@
 			},
 			{
 				"name": "docker.io/moby/buildkit",
-				"tag": "v0.10.4-rootless",
-				"digest": "fc81ed8d967a60bf0e6bff38d4cf9d40be6e815d559c5796c8428cd82fd05674"
+				"tag": "v0.11.3-rootless",
+				"digest": "11b4d498ebe22a78df8ceff259e06fe226f3fa98acd20bdb38ebaa84e119be35"
 			},
 			{
 				"name": "gcr.io/go-containerregistry/crane",

--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -4,7 +4,7 @@ FROM docker.io/fullstorydev/grpcurl:v1.8.7@sha256:d42ef512419560776bee5bb51e338a
 FROM docker.io/mikefarah/yq:4@sha256:d4e1d060e248bdc3ac9e0fccfb4209e24ff42ed3d39beab33d3c3a19480b14fd AS yq
 FROM docker.io/hadolint/hadolint:v2.12.0@sha256:30a8fd2e785ab6176eed53f74769e04f125afb2f74a6c52aef7d463583b6d45e AS hadolint
 FROM --platform=linux/amd64 docker.io/goodwithtech/dockle:v0.4.11@sha256:79ef341552b293f13e7d915747b325c19f6ac47ed4d7bff2bff909fdd493acd7 AS dockle
-FROM docker.io/moby/buildkit:v0.10.6-rootless@sha256:df14db059c966a3329b223f32bb6de6f91711c8f96090e71036fffa983d76eed AS buildkit
+FROM docker.io/moby/buildkit:v0.11.3-rootless@sha256:11b4d498ebe22a78df8ceff259e06fe226f3fa98acd20bdb38ebaa84e119be35 AS buildkit
 FROM gcr.io/go-containerregistry/crane:v0.13.0@sha256:9ddb050949d8e9a37a96d7f9762095c332e015246200dc2984481f1771602fba AS crane
 FROM docker.io/bufbuild/buf:1.12.0@sha256:da02042a9fa7a28ccd7c6f55c8130a5fb5403fdac47cd4c6f96525310e37e8fc AS buf
 FROM docker.io/library/golang:1.19.5-bullseye@sha256:c3feb4bc19853836e788b21051b76b813a30457b3f77058991d3e170af0afa65 AS base


### PR DESCRIPTION
Dependabot is stuck on this dependency, bumping manually
