### PR TITLE
Select the first yaml object to create metadata

### DIFF
--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -78,7 +78,7 @@ vale-sync:
 linguistics-check: validate-pwd vale-sync ## Check spelling, grammar and other linguistics issues
 	vale $(MARKDOWN_FILES)
 
-SITE_NAME := $(shell  yq --no-doc '.metadata.title // .metadata.name' ./catalog-info.yaml)
+SITE_NAME := $(shell yq --no-doc 'select(document_index == 0) | .metadata.title // .metadata.name' ./catalog-info.yaml)
 
 .PHONY: mkdocs.yml
 mkdocs.yml: /usr/local/share/techdocs/mkdocs.yml
@@ -88,7 +88,7 @@ mkdocs.yml: /usr/local/share/techdocs/mkdocs.yml
 build: mkdocs.yml ## Build the website
 	export SITE_NAME="$(SITE_NAME)" && export REPO_NAME=$(REPO_NAME) export REPO_URL=$(REPO_URL) && export EDIT_URI=$(EDIT_URI) && techdocs-cli generate --no-docker
 
-ENTITY := $(shell yq --no-doc '[.metadata.namespace // "default", .kind, .metadata.name] | join("/")' ./catalog-info.yaml)
+ENTITY := $(shell yq --no-doc 'select(document_index == 0) | [.metadata.namespace // "default", .kind, .metadata.name] | join("/")' ./catalog-info.yaml)
 
 serve: mkdocs.yml ## Run a preview site
 	export SITE_NAME="$(SITE_NAME)" && export REPO_NAME=$(REPO_NAME) export REPO_URL=$(REPO_URL) && export EDIT_URI=$(EDIT_URI) && techdocs-cli serve --no-docker

--- a/images/techdocs/tests/prototype/catalog-info.yaml
+++ b/images/techdocs/tests/prototype/catalog-info.yaml
@@ -12,3 +12,17 @@ spec:
   type: library
   lifecycle: experimental
   owner: people
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: test-prototype-2
+  title: Test Prototype 2
+  description: This is a test protoype
+  annotations:
+    github.com/project-slug: example/test-prototype
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: library
+  lifecycle: experimental
+  owner: people


### PR DESCRIPTION
If there are multiple objects in `catalog-info.yaml`, pick the first one
to build the metadata. We current only support TechDocs for 1 Backstage
entity per repository.
