### PR TITLE
Remove `added|modified` from paths filter

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,7 @@ jobs:
           list-files: json
           filters: |
             images:
-              - added|modified: 'images/**'
+              - 'images/**'
       - run: |
           set -x
           wget https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64 -O ${GITHUB_WORKSPACE}/yq


### PR DESCRIPTION
CI was not built initially to remove the images.
This change came from removing poetry-python3.8 image.
Since this image has been remove, we revert the change for the CI.