### PR TITLE
increase timeout for golangci-lint

### DIFF
--- a/images/devtools-golang-v1beta1/context/.golangci.yml
+++ b/images/devtools-golang-v1beta1/context/.golangci.yml
@@ -1,4 +1,6 @@
 # https://golangci-lint.run/usage/configuration/
+run:
+  timeout: 5m
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
Increasing timeout for golangci-lint as I experience timeouts quite often. default is 1m, setting it to 5m.
I don't know if this should be passed as a optional flag in the Makefile instead, and value set by environment variable if set.
That way users of the docker-image can set their own timeout value.
But I think having 5m as a default value for us is also OK.