### PR TITLE
Make it easier to separate devtools from liraries

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,7 +22,7 @@ metadata:
   annotations:
     github.com/project-slug: coopnorge/engineering-docker-images
 spec:
-  type: library
+  type: devtool
   lifecycle: experimental
   owner: engineering
   system: engineering-docker-images
@@ -37,7 +37,7 @@ metadata:
     - devtools
     - go
 spec:
-  type: library
+  type: devtool
   lifecycle: experimental
   owner: engineering
   system: engineering-docker-images
@@ -52,7 +52,7 @@ metadata:
     - devtools
     - kubernetes
 spec:
-  type: library
+  type: devtool
   lifecycle: experimental
   owner: cloud-platform
   system: engineering-docker-images
@@ -67,7 +67,7 @@ metadata:
     - devtools
     - terraform
 spec:
-  type: library
+  type: devtool
   lifecycle: experimental
   owner: cloud-platform
   system: engineering-docker-images
@@ -81,7 +81,7 @@ metadata:
   tags:
     - python
 spec:
-  type: library
+  type: devtool
   lifecycle: production
   owner: cloud-platform
   system: engineering-docker-images
@@ -95,7 +95,7 @@ metadata:
   tags:
     - python
 spec:
-  type: library
+  type: devtool
   lifecycle: production
   owner: cloud-platform
   system: engineering-docker-images
@@ -109,7 +109,7 @@ metadata:
   tags:
     - python
 spec:
-  type: library
+  type: devtool
   lifecycle: deprecated
   owner: cloud-platform
   system: engineering-docker-images
@@ -123,7 +123,7 @@ metadata:
   tags:
     - python
 spec:
-  type: library
+  type: devtool
   lifecycle: production
   owner: cloud-platform
   system: engineering-docker-images
@@ -137,7 +137,7 @@ metadata:
   tags:
     - techdocs
 spec:
-  type: library
+  type: devtool
   lifecycle: production
   owner: cloud-platform
   system: engineering-docker-images


### PR DESCRIPTION
In Inventory we can define the type of a component our selves, devtool
images deserves their own type to make it easier to find. As a result
libraries will also be easier to find.
