### PR TITLE
Add support for hard tabs in code blocks

### DIFF
--- a/images/techdocs/context/markdownlint.yaml
+++ b/images/techdocs/context/markdownlint.yaml
@@ -4,6 +4,9 @@ default: true
 MD007:
   indent: 2  # This is what works in TechDocs
 
+MD010:
+  code_blocks: false
+
 MD033: false
 
 # MD046/code-block-style - Code block style


### PR DESCRIPTION
We use tabs in our Golang code, as such it should be possible to use
tabs when writing examples.