### PR TITLE
Make installing & updating private Go modules easy

### DIFF
--- a/docs/images/devtools-golang-v1beta1.md
+++ b/docs/images/devtools-golang-v1beta1.md
@@ -23,16 +23,6 @@ configuration must be compatible.
    Make sure to not set a passphrase, and to `Configure SSO` to Authorize the
    key for use with coopnorge after you have added it to GitHub.
 
-2. Configure git to access the repositories over SSH instead of HTTPS
-
-    ```console title="Example"
-    git config --global url."git@github.com:example/".insteadOf "https://github.com/example/"
-    ```
-
-    ```console title="Coop specific"
-    git config --global url."git@github.com:coopnorge/".insteadOf "https://github.com/coopnorge/"
-    ```
-
 ### Configuration
 
 Interface variables are configurable with environment variables.

--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -84,7 +84,9 @@ RUN \
 COPY Makefile /usr/local/share/devtools-golang/
 COPY Dockerfile.app /usr/local/share/devtools-golang/
 
-RUN git config --system --add safe.directory /srv/workspace
+RUN git config --system --add safe.directory /srv/workspace; \
+    git config --system url."git@github.com:coopnorge/".insteadOf "https://github.com/coopnorge/"; \
+    go env -w GOPRIVATE=github.com/coopnorge/*
 
 VOLUME /srv/workspace
 WORKDIR /srv/workspace


### PR DESCRIPTION
To install and update our private Go modules from
https://github.com/coopnorge both `git` and `go` must be configured
property.

Since this configuration rarely changes and is not user specific adding
this configuration to the devtools provides for a much improved
developer experience.

Closes: #1221
