### PR TITLE
Revert git config for private Go modules

### DIFF
--- a/docs/images/devtools-golang-v1beta1.md
+++ b/docs/images/devtools-golang-v1beta1.md
@@ -21,7 +21,16 @@ configuration must be compatible.
    ```
 
    Make sure to not set a passphrase, and to `Configure SSO` to Authorize the
-   key for use with coopnorge after you have added it to GitHub.
+
+2. Configure git to access the repositories over SSH instead of HTTPS
+
+   ```console title="Example"
+   git config --global url."git@github.com:example/".insteadOf "https://github.com/example/"
+   ```
+
+   ```console title="Coop specific"
+   git config --global url."git@github.com:coopnorge/".insteadOf "https://github.com/coopnorge/"
+   ```  key for use with coopnorge after you have added it to GitHub.
 
 ### Configuration
 

--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -85,7 +85,6 @@ COPY Makefile /usr/local/share/devtools-golang/
 COPY Dockerfile.app /usr/local/share/devtools-golang/
 
 RUN git config --system --add safe.directory /srv/workspace; \
-    git config --system url."git@github.com:coopnorge/".insteadOf "https://github.com/coopnorge/"; \
     go env -w GOPRIVATE=github.com/coopnorge/*
 
 VOLUME /srv/workspace


### PR DESCRIPTION
When using devtools-golang-v1beta1 in GitHub actions GitHub we are
currently not able to override the system wide configuration.

This means that the git configuration for accessing private Go modules
must be defined outside of the image.

This partially reverts 5af42d88508fa7f3245c5516e2e6eac1ace3d6d7