### PR TITLE
Reduce the amount of PRs to update GitHub Actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,9 +81,9 @@ jobs:
         shell: bash
         run: |
           poetry install -vvv
-      - uses: crazy-max/ghaction-github-runtime@v3.0.0
-      - uses: docker/setup-qemu-action@v3.0.0
-      - uses: docker/setup-buildx-action@v2.10.0
+      - uses: crazy-max/ghaction-github-runtime@v3
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - name: Validate python
         run: |
           make VERBOSE=all validate-python
@@ -108,7 +108,7 @@ jobs:
           make VERBOSE=all -j4 test
       - name: Auth to GCP
         if: github.ref == 'refs/heads/main'
-        uses: "google-github-actions/auth@v1.1.1"
+        uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: projects/943318002566/locations/global/workloadIdentityPools/github-actions/providers/github-actions-provider
           service_account: gha-docker-images@engineering-production-af50.iam.gserviceaccount.com


### PR DESCRIPTION
Most of our references to external GitHub Actions only reference the
major versions. We had a few that referenced the full SemVer, this
caused a lot of pull requests and work.
