### PR TITLE
Install `gomockhandler`

### DIFF
--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -46,6 +46,7 @@ RUN \
     protoc-gen-go --version && \
     protoc-gen-doc --version && \
     mockgen --version && \
+    gomockhandler -h && \
     go-enum --help >/dev/null && \
     modd --version && \
     true

--- a/images/devtools-golang-v1beta1/context/go.mod
+++ b/images/devtools-golang-v1beta1/context/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cortesi/modd v0.8.1
 	github.com/envoyproxy/protoc-gen-validate v1.0.2
 	github.com/pseudomuto/protoc-gen-doc v1.5.1
+	github.com/sanposhiho/gomockhandler v1.4.4
 	go.uber.org/mock v0.3.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 	google.golang.org/protobuf v1.31.0

--- a/images/devtools-golang-v1beta1/context/go.sum
+++ b/images/devtools-golang-v1beta1/context/go.sum
@@ -232,6 +232,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sanposhiho/gomockhandler v1.4.4 h1:t6uKDEETY8abqEQHVbkta79fK+9krZU5msP3z02zK8A=
+github.com/sanposhiho/gomockhandler v1.4.4/go.mod h1:I4cmAHBbKTnQ3U7rHellS76CxxcEKpxuqlHGGFHaTEw=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/spf13/afero v1.9.3 h1:41FoI0fD7OR7mGcKE/aOiLkGreyf8ifIOQmJANWogMk=

--- a/images/devtools-golang-v1beta1/context/tools.go
+++ b/images/devtools-golang-v1beta1/context/tools.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/cortesi/modd/cmd/modd"                        // toolchain
 	_ "github.com/envoyproxy/protoc-gen-validate"               // toolchain
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc" // toolchain
+	_ "github.com/sanposhiho/gomockhandler"                     // toolchain
 	_ "go.uber.org/mock/mockgen"                                // toolchain
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"           // toolchain
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"            // toolchain

--- a/images/devtools-golang-v1beta1/tests/test_image.py
+++ b/images/devtools-golang-v1beta1/tests/test_image.py
@@ -386,6 +386,7 @@ def prototype_ro() -> Generator[Path, None, None]:
         "grpcurl --version".split(),
         "modd --version".split(),
         "mockgen -version".split(),
+        "gomockhandler -h".split(),
         "protoc-gen-go --version".split(),
         "protoc-gen-go-grpc -version".split(),
         "buf --version".split(),


### PR DESCRIPTION
Several of our repositories uses gomockhandler, bundling the tools with
our devtools will make things easier for engineers.
