### PR TITLE
fix: techdocs now requires additional permission

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -131,6 +131,7 @@ jobs:
       contents: read
       id-token: write
       packages: read
+      pull-requests: read
     name: TechDocs
     uses: coopnorge/github-workflow-techdocs/.github/workflows/techdocs.yaml@v0
 


### PR DESCRIPTION
[See](https://github.com/coopnorge/engineering-docker-images/actions/runs/7004437459) for failing build.

Techdocs now requires read permission on pull-request.
[See](https://github.com/coopnorge/github-workflow-techdocs/blob/v0/.github/workflows/techdocs.yaml#L36)