### PR TITLE
fix: re-trigger image build

### DIFF
--- a/images/poetry-python3.10/context/Dockerfile
+++ b/images/poetry-python3.10/context/Dockerfile
@@ -59,4 +59,4 @@ RUN git config --system --add safe.directory /srv/workspace
 VOLUME /srv/workspace
 WORKDIR /srv/workspace
 
-CMD ["validate"]
+CMD ["poetry-install", "validate"]


### PR DESCRIPTION
Re-trigger build as previous build on main failed because of
techdocs workflow needed additional permission.

#1457 fixed the issue and this PR, when merged
should re-build images.
