### PR TITLE
chore: adding missing yq binary to python3.10 devtools

### DIFF
--- a/images/devtools-python3.10-v1beta1/context/Dockerfile
+++ b/images/devtools-python3.10-v1beta1/context/Dockerfile
@@ -3,6 +3,7 @@ FROM docker.io/hadolint/hadolint:v2.12.0@sha256:30a8fd2e785ab6176eed53f74769e04f
 FROM --platform=linux/amd64 docker.io/goodwithtech/dockle:v0.4.13@sha256:2e933954456219021389d1eec5fd09b35d89ff17fe7445abc0fc5748f71d7ae1 AS dockle
 FROM docker.io/moby/buildkit:v0.12.3-rootless@sha256:1e4f2dde8f98019c021badb5909025c18aea83d4ce620e0c5c5b1c926d7f0dc0 AS buildkit
 FROM gcr.io/go-containerregistry/crane:v0.15.2@sha256:be47a641ac6b98004251e1dccdd6fe8cbfca233d1239c751d3eb142608ab3fee AS crane
+FROM docker.io/mikefarah/yq:4@sha256:829bbc4d276ecac5c8df73d6900c5b2c1d74b5ff26129b6562276fb32fde8680 AS yq
 
 FROM python as base
 
@@ -26,6 +27,7 @@ COPY --from=hadolint /bin/hadolint /usr/local/bin/hadolint
 COPY --from=dockle /usr/bin/dockle /usr/local/bin/dockle
 COPY --from=buildkit /usr/bin/buildkit* /usr/bin/buildctl* /usr/bin/rootlesskit /usr/local/bin/
 COPY --from=crane /ko-app/crane /usr/local/bin/
+COPY --from=yq /usr/bin/yq /usr/local/bin/yq
 
 COPY requirements.txt requirements.txt
 RUN python3 -m venv $POETRY_HOME && \


### PR DESCRIPTION
The re-usable workflow we use for building and validating oci,
[see](https://github.com/coopnorge/github-workflow-devtools-build-oci/blob/main/.github/workflows/oci-ci.yaml#L97)
expects yq binary to be there to get image name from oci-metadata.
