### PR TITLE
deps: added python3.10 devtols to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,3 +82,11 @@ updates:
     directory: "images/techdocs/context/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "images/devtools-python3.10-v1beta1/context/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "images/devtools-python3.10-v1beta1/context/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
[See](https://github.com/coopnorge/engineering-docker-images/pull/1487#pullrequestreview-1761903094)
for the review that suggested adding this change.
