### PR TITLE
feat: python3.10 devtools, allow setting python source directory

### DIFF
--- a/images/devtools-python3.10-v1beta1/context/Makefile
+++ b/images/devtools-python3.10-v1beta1/context/Makefile
@@ -3,7 +3,7 @@
 SHELL=bash
 .SHELLFLAGS=-ec -o pipefail
 PYTHON_BIN?=python
-py_source=./src ./tests
+py_source?=./src ./tests
 
 # Load settings.
 $(if $(wildcard devtools-settings.mk),$(info loading devtools-settings.mk)$(eval include devtools-settings.mk),)


### PR DESCRIPTION
Currently, python3.10 devtools expects `py_source` to be `.src` and
`.tests`.

However, when trying to use the devtools with other project, we noticed
that not all systems use the same project structure.
This change will allow us to set the py_source variable either via
env or commandline argument.
