### PR TITLE
Remove wrong CI "approval" check

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -1,15 +1,10 @@
 policy:
   approval:
-  - CI
   - or:
     - Dependabot update
     - Code change
 
 approval_rules:
-- name: CI
-  if:
-    has_successful_status:
-      - "build"
 - name: Dependabot update
   requires:
     count: 1


### PR DESCRIPTION
CI can't be required using Policy Bot. Combining GitHub status checks
and Policy Bot for approvals solves the problem.

Depends on:
- https://github.com/coopnorge/cloud-projects/pull/3977
