### PR TITLE
Enable single review for bot update to Dockerfile.app

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -24,6 +24,7 @@ approval_rules:
     only_changed_files:
       paths:
       - ".*Dockerfile$"
+      - ".*Dockerfile.app$"
       - ".*go.mod$"
       - ".*go.sum$"
       - ".*package-lock.json$"


### PR DESCRIPTION
`Dockerfile.app` is used to create pre-defined Dockerfiles for
applications, Dependabot updates to these should require 1 reviewer.
