### PR TITLE
Add support for embedding files

### DIFF
--- a/images/techdocs/context/mkdocs.yml
+++ b/images/techdocs/context/mkdocs.yml
@@ -25,6 +25,7 @@ markdown_extensions:
   - toc:
       permalink: true
   - pymdownx.tilde
+  - pymdownx.snippets
   - pymdownx.tasklist
   - pymdownx.emoji
   - pymdownx.tabbed:


### PR DESCRIPTION
The [pymdownx.snippets][1] extension enables embedding of external
files. This is particular useful for diagrams and larger code examples.

[1]: https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#snippets
