### PR TITLE
Support appending to the supplied Dockerfile in devtools-golang

### DIFF
--- a/docs/images/devtools-golang-v1beta1.md
+++ b/docs/images/devtools-golang-v1beta1.md
@@ -94,8 +94,35 @@ volumes:
     For this to be more secure of a rootless OCI runtime
     (e.g. rootless dockerd) should be used.
 
-The `Dockerfile` must have a stage named `runtime`, and this is the stage that
-will be pushed when running `publish`.
+This devtool provides a simple Dockerfile which should cover typical service use
+cases. To use it set the `APP_DOCKERFILE` variable to
+`/usr/local/share/devtools-golang/Dockerfile.app`. Complex use cases can
+otherwise supply their own Dockerfile.
+
+A `Dockerfile` supplied by `APP_DOCKERFILE` must have a stage named `runtime`,
+and this is the stage that will be pushed when running the `publish` make
+target.
+
+It is possible to supplement the devtool-supplied Dockerfile by appending
+additional commands. This is particularly useful when only a small set of
+customisations are required. To do this:
+
+- Provide a Dockerfile with the additional commands, and set its path in
+  `APP_DOCKERFILE`.
+- Set `APPEND_APP_DOCKERFILE=true`
+
+In the above case the provided Dockerfile will be concatenated to the
+devtool-supplied one. As such it is not necessary to begin the Dockerfile with a
+`FROM` statement.
+
+Example Dockerfile.app when extending the devtool-supplied one:
+
+```Dockerfile
+# APPEND_APP_DOCKERFILE has been set. The following commands are appended to
+# the devtools app Docker image.
+
+COPY --chown=root:root app-resources /usr/local/your-app/resources
+```
 
 When pushing docker images credentials from `~/.docker/config.json` will be
 used, and these can be set using commands like:

--- a/docs/images/devtools-golang-v1beta1.md
+++ b/docs/images/devtools-golang-v1beta1.md
@@ -153,6 +153,13 @@ printenv GITHUB_TOKEN \
 
   Default: `build/package/Dockerfile`.
 
+- `APPEND_APP_DOCKERFILE`: `true` or `false` indicating whether to append the
+  supplied Dockerfile in `APP_DOCKERFILE` to the one provided by the devtool.
+
+  Allows for simple customisations.
+
+  Default: `false`.
+
 - `BUILD_OCI`: `true` or `false` indicating whether to build an OCI image.
 
   Default: This defaults to `true` if a user supplied `APP_DOCKERFILE` exists

--- a/images/devtools-golang-v1beta1/context/Makefile
+++ b/images/devtools-golang-v1beta1/context/Makefile
@@ -60,11 +60,13 @@ endef
 ## Variable APP_EXECUTABLE : The main executable of the application, defaults to APP_NAME
 ## Variable ENVIRONMENT : The environment name to use. If set variables will be loaded from env.$(ENVIRONMENT)
 ## Variable APP_DOCKERFILE : The path to the Dockerfile to use for building OCI images. Defaults to `build/package/Dockerfile`.
+## Variable APPEND_APP_DOCKERFILE : boolean(true,false) indicating if the $(APP_DOCKERFILE) should be appended to the devtool supplied Dockerfile.
 ## Variable BUILD_OCI : boolean (true,false) indicating if OCI should be built. Defaults to true if $(APP_DOCKERFILE) exists
 ## Variable ENABLE_BUF: boolean (true,false) indicating if buf should be enabled. Defaults to true if buf.work.yaml exists
 ## Variable DELVE_PORT: integer for which port Delve should start the debug-server on. Defaults to 4000.
 APP_EXECUTABLE?=$(APP_NAME)
 APP_DOCKERFILE?=build/package/Dockerfile
+APPEND_APP_DOCKERFILE?=false
 BUILD_OCI?=$(if $(wildcard $(APP_DOCKERFILE)),true,false)
 XDG_CACHE_HOME?=$(HOME)/.cache
 ENABLE_BUF?=$(if $(wildcard buf.work.yaml),true,false)
@@ -91,12 +93,13 @@ go_ldflags?= \
 
 go_build_flags?=
 
+share_dir?=/usr/local/share/devtools-golang
 localstatedir?=var
 generated_dir?=$(localstatedir)/generated
 stamps_dir?=$(localstatedir)/stamps
 outputs_dir?=$(localstatedir)/outputs
 
-$(call dump_vars,APP_EXECUTABLE APP_DOCKERFILE BUILD_OCI XDG_CACHE_HOME)
+$(call dump_vars,APP_EXECUTABLE APP_DOCKERFILE APPEND_APP_DOCKERFILE BUILD_OCI XDG_CACHE_HOME)
 
 ########################################################################
 # generic targets
@@ -279,6 +282,9 @@ endif
 # OCI
 ########################################################################
 
+combined_dockerfile_path=$(localstatedir)/Dockerfile.combined
+app_final_dockerfile=$(if $(call parse_bool,$(APPEND_APP_DOCKERFILE)),$(combined_dockerfile_path),$(APP_DOCKERFILE))
+
 oci_rebuild=false
 oci_context_dir?=.
 oci_images_dir=$(localstatedir)/oci_images
@@ -294,7 +300,7 @@ oci-context: golang-build-outputs
 
 .PHONY: oci-dockerfile-validate
 oci-dockerfile-validate: ## validate the dockerfile
-oci-dockerfile-validate: $(APP_DOCKERFILE)
+oci-dockerfile-validate: $(app_final_dockerfile)
 	hadolint $(<)
 
 oci_tag_prefix=
@@ -333,9 +339,14 @@ oci_build_args ?= \
 
 $(call dump_vars,OCI_REF_NAMES OCI_REFS_REMOTE oci_build_args OCI_BUILD_ARGS)
 
+ifneq ($(call parse_bool,$(APPEND_APP_DOCKERFILE)),)
+$(combined_dockerfile_path): $(share_dir)/Dockerfile.app $(APP_DOCKERFILE)
+	cat $^ > $(combined_dockerfile_path)
+endif
+
 buildctl=buildctl-daemonless.sh
 
-oci-build-stage-%: $(APP_DOCKERFILE) oci-dockerfile-validate | $(oci_images_dir)/ $(oci_context_dir)/ $(oci_cache_dir)/
+oci-build-stage-%: $(app_final_dockerfile) oci-dockerfile-validate | $(oci_images_dir)/ $(oci_context_dir)/ $(oci_cache_dir)/
 	$(buildctl) build \
 		--export-cache type=local,dest=$(oci_cache_dir) \
 		--import-cache type=local,src=$(oci_cache_dir) \

--- a/images/devtools-golang-v1beta1/tests/test_image.py
+++ b/images/devtools-golang-v1beta1/tests/test_image.py
@@ -267,7 +267,8 @@ def test_alterations(
 
 def append_to_file(file_path: Path, lines: Iterable[str]) -> None:
     with file_path.open("a") as tio:
-        tio.writelines(lines)
+        for line in lines:
+            tio.writelines(f"{line}\n")
 
 
 def test_docker_build_app_defined(test_helper: TestHelper) -> None:
@@ -286,7 +287,29 @@ def test_docker_build_app_defined(test_helper: TestHelper) -> None:
     assert "dockle" in captured.all()
     assert "var/oci_images/stage-runtime.oci.tar" in captured.all()
     assert "Dockerfile.app" not in captured.all()
+    assert "Dockerfile.combined" not in captured.all()
     assert "4eda66c7-5bbf-4fec-b855-8a208bb10760" in captured.all()
+
+
+def test_docker_build_app_append(test_helper: TestHelper) -> None:
+    workdir = test_helper.workdir
+    append_to_file(
+        (workdir / "build/package/Dockerfile"),
+        ["RUN echo 7b747541-343e-4908-a760-b35cd2e703b6"],
+    )
+    append_to_file(
+        (workdir / "devtools.env"),
+        ["BUILD_OCI=true", "APPEND_APP_DOCKERFILE=true"],
+    )
+    test_helper.run(command_extra=["bash", "-c", "time validate"])
+    captured = test_helper.captured()
+    assert "var/oci_images/stage-runtime.oci.tar" in captured.all()
+    assert "Dockerfile.combined" in captured.all()
+    assert "7b747541-343e-4908-a760-b35cd2e703b6" in captured.all()
+
+    with (workdir / "var/Dockerfile.combined").open() as df:
+        found = "7b747541-343e-4908-a760-b35cd2e703b6" in df.read()
+        assert found
 
 
 def test_prototype_failing_tests(tmp_path: Path, capfd: CaptureFixture[str]) -> None:


### PR DESCRIPTION
The Golang devtools support the building of an OCI either from a
devtool-supplied Dockerfile, or when customizations are required, a
user-supplied Dockerfile.

To avoid unnecessary duplication of the supplied Dockerfile in the case
where only a few additional Dockerfile commands are needed, add support
for modifying it via an append.
