### PR TITLE
Support copying of additional resource files in devtool-supplied OCI image

### DIFF
--- a/docs/images/devtools-golang-v1beta1.md
+++ b/docs/images/devtools-golang-v1beta1.md
@@ -94,8 +94,19 @@ volumes:
     For this to be more secure of a rootless OCI runtime
     (e.g. rootless dockerd) should be used.
 
-The `Dockerfile` must have a stage named `runtime`, and this is the stage that
-will be pushed when running `publish`.
+This devtool provides a simple Dockerfile which should cover typical service use
+cases. To use it set the `APP_DOCKERFILE` variable to
+`/usr/local/share/devtools-golang/Dockerfile.app`. Complex use cases can
+otherwise supply their own Dockerfile.
+
+A `Dockerfile` supplied by `APP_DOCKERFILE` must have a stage named `runtime`,
+and this is the stage that will be pushed when running the `publish` make
+target.
+
+When using the devtool-supplied Dockerfile, it is possible to copy additional
+resource files required by an application to the application's working directory
+(`/var/opt/${APP_NAME}`), see `APP_RESOURCE_PATHS` below. This requires that the
+devtool-supplied Dockerfile is specified in `APP_DOCKERFILE`.
 
 When pushing docker images credentials from `~/.docker/config.json` will be
 used, and these can be set using commands like:
@@ -125,6 +136,11 @@ printenv GITHUB_TOKEN \
 - `APP_DOCKERFILE`: The dockerfile to use when building an OCI image.
 
   Default: `build/package/Dockerfile`.
+
+- `APP_RESOURCE_PATHS`: A space-separated list of paths to copy to the
+  application's working directory. Paths will be chowned to `root`:`root`.
+
+  Default: unset.
 
 - `BUILD_OCI`: `true` or `false` indicating whether to build an OCI image.
 

--- a/images/devtools-golang-v1beta1/context/Dockerfile.app
+++ b/images/devtools-golang-v1beta1/context/Dockerfile.app
@@ -41,6 +41,9 @@ RUN \
 
 COPY --chown=root:root ${outputs_dir}/${app_executable} /usr/local/bin/${app_executable}
 
+# The following line will be replaced by COPY statements for resource paths if any are provided in $APP_RESOURCE_PATHS
+# @app_resource_commands
+
 RUN \
     chmod ugo-w /usr/local/bin/${app_executable}
 

--- a/images/devtools-golang-v1beta1/context/Makefile
+++ b/images/devtools-golang-v1beta1/context/Makefile
@@ -60,11 +60,13 @@ endef
 ## Variable APP_EXECUTABLE : The main executable of the application, defaults to APP_NAME
 ## Variable ENVIRONMENT : The environment name to use. If set variables will be loaded from env.$(ENVIRONMENT)
 ## Variable APP_DOCKERFILE : The path to the Dockerfile to use for building OCI images. Defaults to `build/package/Dockerfile`.
+## Variable APP_RESOURCE_PATHS: A space-separated list of paths to copy to the application's working directory (See WORKDIR in Dockerfile.app)
 ## Variable BUILD_OCI : boolean (true,false) indicating if OCI should be built. Defaults to true if $(APP_DOCKERFILE) exists
 ## Variable ENABLE_BUF: boolean (true,false) indicating if buf should be enabled. Defaults to true if buf.work.yaml exists
 ## Variable DELVE_PORT: integer for which port Delve should start the debug-server on. Defaults to 4000.
 APP_EXECUTABLE?=$(APP_NAME)
 APP_DOCKERFILE?=build/package/Dockerfile
+APP_RESOURCE_PATHS?=
 BUILD_OCI?=$(if $(wildcard $(APP_DOCKERFILE)),true,false)
 XDG_CACHE_HOME?=$(HOME)/.cache
 ENABLE_BUF?=$(if $(wildcard buf.work.yaml),true,false)
@@ -96,7 +98,7 @@ generated_dir?=$(localstatedir)/generated
 stamps_dir?=$(localstatedir)/stamps
 outputs_dir?=$(localstatedir)/outputs
 
-$(call dump_vars,APP_EXECUTABLE APP_DOCKERFILE BUILD_OCI XDG_CACHE_HOME)
+$(call dump_vars,APP_EXECUTABLE APP_DOCKERFILE APP_RESOURCE_PATHS BUILD_OCI XDG_CACHE_HOME)
 
 ########################################################################
 # generic targets
@@ -284,6 +286,10 @@ oci_context_dir?=.
 oci_images_dir=$(localstatedir)/oci_images
 oci_cache_dir=$(XDG_CACHE_HOME)/buildkit
 
+imbue_dockerfile=$(if $(strip $(APP_RESOURCE_PATHS)),true,false)
+imbued_dockerfile_path=$(localstatedir)/Dockerfile.imbued
+app_final_dockerfile=$(if $(call parse_bool,$(imbue_dockerfile)),$(imbued_dockerfile_path),$(APP_DOCKERFILE))
+
 .PHONY: oci-clean-images
 clean: oci-clean-context
 oci-clean-images: clean-$(oci_images_dir)/
@@ -294,7 +300,7 @@ oci-context: golang-build-outputs
 
 .PHONY: oci-dockerfile-validate
 oci-dockerfile-validate: ## validate the dockerfile
-oci-dockerfile-validate: $(APP_DOCKERFILE)
+oci-dockerfile-validate: $(app_final_dockerfile)
 	hadolint $(<)
 
 oci_tag_prefix=
@@ -333,9 +339,21 @@ oci_build_args ?= \
 
 $(call dump_vars,OCI_REF_NAMES OCI_REFS_REMOTE oci_build_args OCI_BUILD_ARGS)
 
+ifneq ($(call parse_bool,$(imbue_dockerfile)),)
+resource_dirs_quoteless = $(subst ',,$(subst $\",,$(APP_RESOURCE_PATHS)))
+copy_command =\
+	$(foreach entry,$(resource_dirs_quoteless),\nCOPY --chown=root:root $(entry) $$\{workdir}/$(entry))
+
+.PHONY: $(imbued_dockerfile_path)
+$(imbued_dockerfile_path): $(APP_DOCKERFILE)
+	sed -e 's|# @app_resource_commands|$(copy_command)|' $< > $(imbued_dockerfile_path)
+
+$(call dump_vars,imbued_dockerfile_path resource_dirs_quoteless copy_command)
+endif
+
 buildctl=buildctl-daemonless.sh
 
-oci-build-stage-%: $(APP_DOCKERFILE) oci-dockerfile-validate | $(oci_images_dir)/ $(oci_context_dir)/ $(oci_cache_dir)/
+oci-build-stage-%: $(app_final_dockerfile) oci-dockerfile-validate | $(oci_images_dir)/ $(oci_context_dir)/ $(oci_cache_dir)/
 	$(buildctl) build \
 		--export-cache type=local,dest=$(oci_cache_dir) \
 		--import-cache type=local,src=$(oci_cache_dir) \


### PR DESCRIPTION
The Golang devtools support the building of an OCI image for an application either from a devtool-supplied Dockerfile, or when significant customizations are required, a user-supplied Dockerfile.

To avoid unnecessary duplication of the supplied Dockerfile in the case where only a few additional resource files are needed, add support for copying a list of paths into the application's working directory.

This is an opinionated approach, however it should be possible to convert all remaining Go projects that supply their own Dockerfile to use the built in one either by using this feature alone, or with a little additional restructuring of env-specific things into ConfigMaps.