### PR TITLE
fix: Change how `TFDIRS_EXCLUDE` is interpreted

### DIFF
--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -47,10 +47,10 @@ TFDIRS?=$(shell find . -name .terraform -prune -o \( -name '*.tf' -print \) \
 	| sort | uniq)
 
 # Filter out the directories specified in TFDIRS_EXCLUDE
-TFDIRS := $(filter-out $(TFDIRS_EXCLUDE),$(TFDIRS))
+override TFDIRS := $(filter-out $(TFDIRS_EXCLUDE),$(TFDIRS))
 
 # If TFDIRS is still empty, default to the current directory
-TFDIRS := $(or $(TFDIRS),.)
+override TFDIRS := $(or $(TFDIRS),.)
 
 TF_NO_PROVIDERS=
 

--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -41,10 +41,16 @@ terraform_docs_config=terraform-docs.yml
 TFDIRS_EXCLUDE?=%/examples %/example
 $(info TFDIRS_EXCLUDE=$(TFDIRS_EXCLUDE))
 
-TFDIRS?=$(filter-out $(TFDIRS_EXCLUDE), \
-	$(or $(shell find . -name .terraform -prune -o \( -name '*.tf' -print \) \
-		| sed 's|/[^/]\{1,\}$$||g' \
-		| sort | uniq),.))
+# Find directories containing Terraform files if TFDIRS is not already set
+TFDIRS?=$(shell find . -name .terraform -prune -o \( -name '*.tf' -print \) \
+	| sed 's|/[^/]\{1,\}$$||g' \
+	| sort | uniq)
+
+# Filter out the directories specified in TFDIRS_EXCLUDE
+TFDIRS := $(filter-out $(TFDIRS_EXCLUDE),$(TFDIRS))
+
+# If TFDIRS is still empty, default to the current directory
+TFDIRS := $(or $(TFDIRS),.)
 
 TF_NO_PROVIDERS=
 

--- a/images/devtools-terraform-v1beta1/tests/test_image.py
+++ b/images/devtools-terraform-v1beta1/tests/test_image.py
@@ -254,9 +254,9 @@ def test_prototype_env_vars(
         subprocess.run(devtools_cmd(["validate", "TFDIRS="]), check=True)
 
         cap = Captured.from_capfd(capfd)
-        assert sum("No problems detected" in line for line in cap.out_lines) == 0
-        assert sum("tfsec" in line for line in cap.out_lines) == 0
-        assert sum("tflint" in line for line in cap.out_lines) == 0
+        assert sum("No problems detected" in line for line in cap.out_lines) == 1
+        assert sum("tfsec" in line for line in cap.out_lines) == 1
+        assert sum("tflint" in line for line in cap.out_lines) == 1
 
         (workdir / "blank").mkdir()
         subprocess.run(

--- a/images/devtools-terraform-v1beta1/tests/test_image.py
+++ b/images/devtools-terraform-v1beta1/tests/test_image.py
@@ -282,6 +282,84 @@ def test_prototype_env_vars(
         assert sum("tflint" in line for line in cap.out_lines) == 1
 
 
+def test_dir_exclusion_behavior(
+    tmp_path: Path,
+    cache_dir: Optional[Path],
+    capfd: CaptureFixture[str],
+) -> None:
+    with ctx_prototype(tmp_path, cache_dir):  # as workdir:
+        # default values
+        subprocess.run(devtools_cmd(), check=True)
+        cap = Captured.from_capfd(capfd)
+        assert (
+            sum("TFDIRS_EXCLUDE=%/examples %/example" == line for line in cap.out_lines)
+            == 1
+        )
+        assert sum("TFDIRS=. ./eg_module" == line for line in cap.out_lines) == 1
+
+        # TFDIRS_EXCLUDE override using env var
+        subprocess.run(
+            devtools_cmd(
+                ["validate"], envargs={"TFDIRS_EXCLUDE": "./eg_exclusion_module"}
+            ),
+        )
+        cap = Captured.from_capfd(capfd)
+        assert (
+            sum(
+                "TFDIRS_EXCLUDE=./eg_exclusion_module" == line for line in cap.out_lines
+            )
+            == 1
+        )
+        assert (
+            sum(
+                "TFDIRS=. ./eg_module ./example ./examples" == line
+                for line in cap.out_lines
+            )
+            == 1
+        )
+
+        # TFDIRS_EXCLUDE override using command line
+        subprocess.run(
+            devtools_cmd(["validate", "TFDIRS_EXCLUDE=./eg_exclusion_module"]),
+        )
+        cap = Captured.from_capfd(capfd)
+        assert (
+            sum(
+                "TFDIRS_EXCLUDE=./eg_exclusion_module" == line for line in cap.out_lines
+            )
+            == 1
+        )
+        assert (
+            sum(
+                "TFDIRS=. ./eg_module ./example ./examples" == line
+                for line in cap.out_lines
+            )
+            == 1
+        )
+
+        # check if TFDIRS_EXCLUDE is applied if TFDIRS is set via env var
+        subprocess.run(
+            devtools_cmd(["validate"], envargs={"TFDIRS": "./ ./example ./examples"}),
+        )
+        cap = Captured.from_capfd(capfd)
+        assert sum("TFDIRS=./" == line for line in cap.out_lines) == 1
+        assert (
+            sum("TFDIRS_EXCLUDE=%/examples %/example" == line for line in cap.out_lines)
+            == 1
+        )
+
+        # check if TFDIRS_EXCLUDE is applied if TFDIRS is set via command line
+        subprocess.run(
+            devtools_cmd(["validate", "TFDIRS=./ ./example ./examples"]),
+        )
+        cap = Captured.from_capfd(capfd)
+        assert sum("TFDIRS=./" == line for line in cap.out_lines) == 1
+        assert (
+            sum("TFDIRS_EXCLUDE=%/examples %/example" == line for line in cap.out_lines)
+            == 1
+        )
+
+
 def test_prototype_fail_fmt(
     tmp_path: Path,
     cache_dir: Optional[Path],


### PR DESCRIPTION
`TFDIRS_EXCLUDE` was being ignored if `TFDIRS` was already set via env vars. 

This change makes sure that the excludes apply regardless of how `TFDIRS` is set. If the user wants to make sure that examples aren't excluded, it needs to be explicitly done by setting `TFDIRS_EXCLUDE`.

This change is related to the following issue: https://github.com/coopnorge/github-workflow-terraform-validation/issues/72