### PR TITLE
chore: Bump Debian from Bullseye (11) to Bookworm (12)

### DIFF
--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -7,7 +7,7 @@ FROM --platform=linux/amd64 docker.io/goodwithtech/dockle:v0.4.13@sha256:2e93395
 FROM docker.io/moby/buildkit:v0.12.5-rootless@sha256:917dfee8b44c29c14e534c10ad406976a9467d9af556d7d7be840c39713b329b AS buildkit
 FROM gcr.io/go-containerregistry/crane:v0.15.2@sha256:be47a641ac6b98004251e1dccdd6fe8cbfca233d1239c751d3eb142608ab3fee AS crane
 FROM docker.io/bufbuild/buf:1.29.0@sha256:fbb893823421e46c6a8830b766bc54804fe09df33c60f16d7ae9293e8e27ec1b AS buf
-FROM docker.io/library/golang:1.21.6-bullseye@sha256:c62751ac12cad0c514d941e36f846c1c440ca9e8ec08dd87d022fb03f0887a9b AS base
+FROM docker.io/library/golang:1.21.6-bookworm@sha256:efe985ec6ca642b035ea2896c7e975f0ec04063bcdb206bbff0d4e1c74ba3ff7 AS base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Bullseye was released 14 August 2021, and has Security-EOL in July 2024.
Bookworm was released 10 June 2023, and har Security-EOL in June 2026.

https://en.wikipedia.org/wiki/Debian_version_history