### PR TITLE
chore: Only validate against major version of markdownlint

### DIFF
--- a/images/techdocs/tests/test_image.py
+++ b/images/techdocs/tests/test_image.py
@@ -36,7 +36,7 @@ def volumes() -> dict[str, dict[str, str]]:
     "cli_command,expected_ouput",
     [
         ("techdocs-cli --version", b"1."),
-        ("markdownlint --version", b"0.38."),
+        ("markdownlint --version", b"0."),
         ("vale --version", b"vale version v2."),
         ("yq --version", b"yq (https://github.com/mikefarah/yq/) version v4."),
     ],


### PR DESCRIPTION
There is no reason to lock markdownlint to a minor version. This just
causes friction when updating the image.