### PR TITLE
chore: Update openjdk version

### DIFF
--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -31,10 +31,10 @@ RUN ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/c
     && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    openjdk-17-jdk-headless=17.0.11+9-1~deb12u1 \
-    openjdk-17-jdk=17.0.11+9-1~deb12u1 \
-    openjdk-17-jre-headless=17.0.11+9-1~deb12u1 \
-    openjdk-17-jre=17.0.11+9-1~deb12u1 \
+    openjdk-17-jdk-headless=17.0.12+7-2~deb12u1 \
+    openjdk-17-jdk=17.0.12+7-2~deb12u1 \
+    openjdk-17-jre-headless=17.0.12+7-2~deb12u1 \
+    openjdk-17-jre=17.0.12+7-2~deb12u1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
ci fails because the old version is no longer available in apt