### PR TITLE
Revert "build(deps): bump python in /images/devtools-python3.10-v1beta1/context (#2241)"

### DIFF
--- a/images/devtools-python3.10-v1beta1/context/Dockerfile.app
+++ b/images/devtools-python3.10-v1beta1/context/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.13-slim@sha256:2ec5a4a5c3e919570f57675471f081d6299668d909feabd8d4803c6c61af666c AS python
+FROM docker.io/python:3.10-slim@sha256:a2c9b8dd3da225debeb156176c111752499d152b7505146c1373364766d762a4 AS python
 
 FROM python AS runtime
 


### PR DESCRIPTION
This is a devtool for python 3.10, it doesn't make sense to upgrade
the python version 3.13.

Reverting https://github.com/coopnorge/engineering-docker-images/pull/2241.
