### PR TITLE
fix: Use .trivyignore from the terraform directory being checked instead repo root

### DIFF
--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -117,7 +117,7 @@ validate-tf-$(1): | $(1)/.terraform $(if $(TF_NO_PROVIDERS),,$(1)/.terraform/pro
 	cd $(1) && $$(tfswitch)
 	cd $(1) && $$(terraform) fmt -check -recursive -diff
 	cd $(1) && $$(terraform) validate
-	test -e "$(1)/.tfsec-ignore" || test -e "$(1)/.trivy-ignore" || $$(trivy) $(1)
+	test -e "$(1)/.tfsec-ignore" || test -e "$(1)/.trivy-ignore" || $$(trivy) --ignorefile="$(1)/.trivyignore" "$(1)"
 	[ ! -f "$(1)/$(terraform_docs_config)" ] || (echo "Validating documentation with $$(tfdocs_version)" ; $$(tfdocs_check) )
 	$$(tflint) --chdir=$(1)
 


### PR DESCRIPTION
It seems that trivyignore is not working as expected (as we have tried to use in cloud-projects: https://github.com/coopnorge/cloud-projects/pull/5160). It expects `.trivyignore` in project root. We want to have it in the terraform directory (directories where the terraform files are).
