### PR TITLE
Revert "chore: Use workaround for trivy (#2269)"

### DIFF
--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -72,7 +72,7 @@ $(call dump_vars,tf_plugin_cache_dir_target TF_PLUGIN_CACHE_DIR)
 	cd $(*) && $(tfswitch)
 	cd $(*) && $(terraform) init $(terraform_init_args)
 
-trivy=TRIVY_DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-db trivy --cache-dir /tmp/.cache.trivy/ config --exit-code 1 --misconfig-scanners=terraform
+trivy=trivy --cache-dir /tmp/.cache.trivy/ config --exit-code 1 --misconfig-scanners=terraform
 tflint=tflint --enable-plugin=google --enable-plugin=azurerm  --disable-rule=terraform_unused_declarations $(if $(filter all commands,$(VERBOSE)),--loglevel=trace)
 tfdocs_version=$(shell terraform-docs --version)
 tfdocs_check=terraform-docs . -c $(terraform_docs_config) --output-check


### PR DESCRIPTION
This reverts commit 717826c16f700706546ebf9598e923add8871b22.

Undoing the workaround implemented here https://github.com/coopnorge/engineering-docker-images/pull/2269 because I realized that it doesn't actually solve our use-case. The workaround we need for config scanning is related to a different image (`ghcr.io/aquasecurity/trivy-checks:1`), which does not have an alternate mirror at this point (the mirror will be available if/when this is merged: https://github.com/aquasecurity/trivy-checks/pull/262)

ref: https://github.com/coopnorge/cloud-platform-team/issues/997