### PR TITLE
fix: Only pass the ignorefile param to trivy if .trivyignore exists

### DIFF
--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -132,7 +132,8 @@ validate-tf-$(1): | $(1)/.terraform $(if $(TF_NO_PROVIDERS),,$(1)/.terraform/pro
 	cd $(1) && $$(tfswitch)
 	cd $(1) && $$(terraform) fmt -check -recursive -diff
 	cd $(1) && $$(terraform) validate
-	test -e "$(1)/.tfsec-ignore" || test -e "$(1)/.trivy-ignore" || $$(trivy) --ignorefile="$(1)/.trivyignore" "$(1)"
+	test -e "$(1)/.tfsec-ignore" || test -e "$(1)/.trivy-ignore" || \
+        (test -e "$(1)/.trivyignore" && $$(trivy) --ignorefile="$(1)/.trivyignore" "$(1)" || $$(trivy) "$(1)")
 	[ ! -f "$(1)/$(terraform_docs_config)" ] || (echo "Validating documentation with $$(tfdocs_version)" ; $$(tfdocs_check) )
 	$$(tflint) --chdir=$(1)
 


### PR DESCRIPTION
This breaks with trivy 0.57 because missing ignorefile is fatal error now (previously, it would not error on missing ignorefile)

ref: https://github.com/aquasecurity/trivy/discussions/7857
ref: https://github.com/coopnorge/engineering-docker-images/pull/2274