### PR TITLE
fix: Correct directory for trivy cache

### DIFF
--- a/images/devtools-terraform-v1beta1/context/Dockerfile
+++ b/images/devtools-terraform-v1beta1/context/Dockerfile
@@ -88,8 +88,11 @@ COPY Makefile /usr/local/share/devtools-terraform/Makefile
 RUN git config --system --add safe.directory /srv/workspace
 
 # Include the current version of trivy checks db in the image
-RUN cd /var && \
-    oras pull $TRIVY_CHECKS_DB && \
-    mv /var/bundle.tar.gz /var/trivy-checks-db.tar.gz
+SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
+RUN DIGEST=$(oras pull $TRIVY_CHECKS_DB | grep Digest | cut -d' ' -f2) && \
+    mv bundle.tar.gz /var/trivy-checks-db.tar.gz && \
+    DOWNLOADED_AT=$(date +"%Y-%m-%dT%H:%M:%S.%6N%:z") && \
+    echo "{\"Digest\":\"$DIGEST\",\"DownloadedAt\":\"$DOWNLOADED_AT\"}" > /var/trivy-checks-metadata.json
+
 
 CMD ["validate"]

--- a/images/devtools-terraform-v1beta1/context/Makefile
+++ b/images/devtools-terraform-v1beta1/context/Makefile
@@ -78,14 +78,22 @@ $(call dump_vars,trivy_plugin_cache_dir_target TRIVY_CACHE_DIR)
 	cd $(*) && $(terraform) init $(terraform_init_args)
 
 .trivy: | $(trivy_cache_dir_target)
-	cd /tmp
-	mkdir -vp $(trivy_cache_dir_target)bundle
-	# If the trivy cache for the bundle is empty, extract the one included in the image
-	if [ -z "$$(ls -A $(trivy_cache_dir_target)bundle > /dev/null 2>&1)" ]; then \
-		tar -xzf /var/trivy-checks-db.tar.gz -C $(trivy_cache_dir_target)bundle; \
+	mkdir -vp $(trivy_cache_dir_target)policy/content/
+	# If the trivy cache for the policies is empty, extract the one included in the image
+	POLICY_CONTENT=$$(ls -A $(trivy_cache_dir_target)policy/content/); \
+	if [ "$$POLICY_CONTENT" = "" ]; then \
+		tar -xzf /var/trivy-checks-db.tar.gz -C $(trivy_cache_dir_target)policy/content/; \
+		cp /var/trivy-checks-metadata.json $(trivy_cache_dir_target)policy/metadata.json; \
 	fi
-	# Try to update. If the update fails, the error is ignored and, the checks-db included in the image is used.
-	- oras pull $(TRIVY_CHECKS_DB) && tar -xzf bundle.tar.gz -C $(trivy_cache_dir_target)bundle
+	# Try to update. If the update fails, the checks db included in the image (extracted above) is used.
+	- DIGEST=$$(oras pull $(TRIVY_CHECKS_DB) | grep Digest | cut -d' ' -f2); \
+	DOWNLOADED_AT=$$(date +"%Y-%m-%dT%H:%M:%S.%6N%:z"); \
+	if [ -z "$$DIGEST" ]; then \
+		echo "Failed to download trivy-checks db"; \
+	else \
+		tar -xzf bundle.tar.gz -C $(trivy_cache_dir_target)policy/content/; \
+		echo "{\"Digest\":\"$$DIGEST\",\"DownloadedAt\":\"$$DOWNLOADED_AT\"}" > $(trivy_cache_dir_target)policy/metadata.json; \
+	fi
 
 trivy=trivy --cache-dir $(trivy_cache_dir_target) config --exit-code 1 --misconfig-scanners=terraform
 tflint=tflint --enable-plugin=google --enable-plugin=azurerm  --disable-rule=terraform_unused_declarations $(if $(filter all commands,$(VERBOSE)),--loglevel=trace)

--- a/images/devtools-terraform-v1beta1/tests/test_image.py
+++ b/images/devtools-terraform-v1beta1/tests/test_image.py
@@ -178,13 +178,13 @@ def test_prototype_ok(
         subprocess.run(devtools_cmd(), check=True)
 
         cap = Captured.from_capfd(capfd)
-        assert sum("trivy" in line for line in cap.out_lines) == 6
+        assert sum("trivy" in line for line in cap.out_lines) == 7
         assert sum("tflint" in line for line in cap.out_lines) == 2
 
         subprocess.run(devtools_cmd(["maker", "validate"]), check=True)
 
         cap = Captured.from_capfd(capfd)
-        assert sum("trivy" in line for line in cap.out_lines) >= 2
+        assert sum("trivy" in line for line in cap.out_lines) == 7
         assert sum("tflint" in line for line in cap.out_lines) == 2
 
 
@@ -199,7 +199,7 @@ def test_prototype_nocache(
         subprocess.run(devtools_cmd(envargs={"TF_PLUGIN_CACHE_DIR": ""}), check=True)
 
         cap = Captured.from_capfd(capfd)
-        assert sum("trivy" in line for line in cap.out_lines) == 6
+        assert sum("trivy" in line for line in cap.out_lines) == 7
         assert sum("tflint" in line for line in cap.out_lines) == 2
 
 
@@ -217,7 +217,7 @@ def test_prototype_ok_no_module(
         subprocess.run(devtools_cmd(), check=True)
 
         cap = Captured.from_capfd(capfd)
-        assert sum("trivy" in line for line in cap.out_lines) == 5
+        assert sum("trivy" in line for line in cap.out_lines) == 6
         assert sum("tflint" in line for line in cap.out_lines) == 1
 
 
@@ -236,7 +236,7 @@ def test_prototype_reinit_upgrade(
         subprocess.run(devtools_cmd(["validate"]), check=True)
 
         cap = Captured.from_capfd(capfd)
-        assert sum("trivy" in line for line in cap.out_lines) == 12
+        assert sum("trivy" in line for line in cap.out_lines) == 14
         assert sum("tflint" in line for line in cap.out_lines) == 4
 
 
@@ -249,7 +249,7 @@ def test_prototype_env_vars(
         subprocess.run(devtools_cmd(["validate", "TFDIRS="]), check=True)
 
         cap = Captured.from_capfd(capfd)
-        assert sum("trivy" in line for line in cap.out_lines) == 5
+        assert sum("trivy" in line for line in cap.out_lines) == 6
         assert sum("tflint" in line for line in cap.out_lines) == 1
 
         (workdir / "blank").mkdir()
@@ -259,7 +259,7 @@ def test_prototype_env_vars(
         )
 
         cap = Captured.from_capfd(capfd)
-        assert sum("trivy" in line for line in cap.out_lines) >= 1
+        assert sum("trivy" in line for line in cap.out_lines) == 6
         assert sum("tflint" in line for line in cap.out_lines) == 1
 
         subprocess.run(
@@ -270,7 +270,7 @@ def test_prototype_env_vars(
         )
 
         cap = Captured.from_capfd(capfd)
-        assert sum("trivy" in line for line in cap.out_lines) >= 1
+        assert sum("trivy" in line for line in cap.out_lines) == 6
         assert sum("tflint" in line for line in cap.out_lines) == 1
 
 
@@ -518,7 +518,7 @@ def test_prototype_fallback(
         subprocess.run(devtools_cmd(["validate"]), check=True)
 
         cap = Captured.from_capfd(capfd)
-        assert sum("trivy" in line for line in cap.out_lines) == 5
+        assert sum("trivy" in line for line in cap.out_lines) == 6
         assert sum("tflint" in line for line in cap.out_lines) == 1
 
 


### PR DESCRIPTION
Also include and update manifest file.

ref: https://github.com/aquasecurity/trivy/blob/ed2288f1e7b1195db179191e51a1952272c2c064/pkg/policy/policy.go