### PR TITLE
chore: Update openjdk version

### DIFF
--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -31,10 +31,10 @@ RUN ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/c
     && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    openjdk-17-jdk-headless=17.0.12+7-2~deb12u1 \
-    openjdk-17-jdk=17.0.12+7-2~deb12u1 \
-    openjdk-17-jre-headless=17.0.12+7-2~deb12u1 \
-    openjdk-17-jre=17.0.12+7-2~deb12u1 \
+    openjdk-17-jdk-headless=17.0.13+11-2~deb12u1 \
+    openjdk-17-jdk=17.0.13+11-2~deb12u1 \
+    openjdk-17-jre-headless=17.0.13+11-2~deb12u1 \
+    openjdk-17-jre=17.0.13+11-2~deb12u1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The older version is not available anymore in the apt repo. 
ref: https://github.com/coopnorge/engineering-docker-images/actions/runs/11772865000/job/32788884394?pr=2301

previous update: https://github.com/coopnorge/engineering-docker-images/pull/2160