### PR TITLE
fix: Use the full version in go directive

### DIFF
--- a/images/devtools-golang-v1beta1/context/go.mod
+++ b/images/devtools-golang-v1beta1/context/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/engineering-docker-images/images/devtools-golang-v1beta1/context/gotools
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/abice/go-enum v0.6.0

--- a/images/devtools-golang-v1beta1/tests/prototype/go.mod
+++ b/images/devtools-golang-v1beta1/tests/prototype/go.mod
@@ -1,3 +1,3 @@
 module example.com/prototype
 
-go 1.22
+go 1.22.0

--- a/images/devtools-kubernetes-v1beta1/context/go.mod
+++ b/images/devtools-kubernetes-v1beta1/context/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/engineering-docker-images/images/devtools-kubernetes-v1beta1/context/gotools
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/homeport/dyff v1.9.4


### PR DESCRIPTION
failure in codeql run because of this: https://github.com/coopnorge/engineering-docker-images/security/code-scanning/tools/CodeQL/status/configurations/actions-FZTWS5DIOVRC653POJVWM3DPO5ZS643FMN2XE2LUPEWXGY3BNYXHSYLNNQ/bfbcc3db1f0fcfb6fac8a233c4d16a5b92b7e81c26ae172ec8129bcda9a245b2