### PR TITLE
feat: allow user supplied tag in golang devtool

### DIFF
--- a/images/devtools-golang-v1beta1/context/Makefile
+++ b/images/devtools-golang-v1beta1/context/Makefile
@@ -307,11 +307,14 @@ oci-dockerfile-validate: $(app_final_dockerfile)
 
 oci_tag_prefix=
 
+OCI_TAG_SUFFIX_USER=
+
 oci_tag_suffixes_git = \
 	gitc-$(giti_commit_hash) \
 
 oci_tag_suffixes = \
 	$(oci_tag_suffixes_git) \
+	$(OCI_TAG_SUFFIX_USER) \
 
 oci_refs_local=\
 	$(foreach oci_tag_suffix,\


### PR DESCRIPTION
Allow the user to also supply a oci tag for the build
