### PR TITLE
feat: disable hardcoded latest oci tag in python devtools and add user override

### DIFF
--- a/images/devtools-python3.10-v1beta1/context/Makefile
+++ b/images/devtools-python3.10-v1beta1/context/Makefile
@@ -149,15 +149,14 @@ oci-dockerfile-validate: $(APP_DOCKERFILE)
 
 oci_tag_prefix=
 
-oci_tag_suffixes_const = \
-	latest \
+OCI_TAG_SUFFIX_USER=
 
 oci_tag_suffixes_git = \
 	gitc-$(giti_commit_hash) \
 
 oci_tag_suffixes = \
-	$(oci_tag_suffixes_const) \
 	$(oci_tag_suffixes_git) \
+	$(OCI_TAG_SUFFIX_USER) \
 
 oci_refs_local=\
 	$(foreach oci_tag_suffix,\


### PR DESCRIPTION
* disabled hardcoded tag
* allow user to set OCI_TAG_SUFFIX_USER to set a default tag

This allowed for now having the same tag always. This is required to
enable immuttable tags on OCI repos.
