### PR TITLE
feat: Enforce staticcheck ST1005

### DIFF
--- a/images/devtools-golang-v1beta1/context/.golangci.yml
+++ b/images/devtools-golang-v1beta1/context/.golangci.yml
@@ -17,6 +17,7 @@ linters:
   - typecheck
   - unused
   - whitespace
+  - stylecheck
 issues:
   exclude-use-default: false
   exclude-rules:
@@ -38,3 +39,6 @@ linters-settings:
   errcheck:
     check-type-assertions: true
     check-blank: true
+  stylecheck:
+    checks:
+      - "ST1005"

--- a/images/devtools-golang-v1beta1/tests/prototype/main.go
+++ b/images/devtools-golang-v1beta1/tests/prototype/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -10,4 +11,22 @@ import (
 func main() {
 	fmt.Println("2 + 2 =", sum.Sum(2, 2))
 	fmt.Println("os.Args =", os.Args)
+
+	err := badError()
+	if err != nil {
+		panic(err)
+	}
+
+	err = goodError()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func badError() error {
+	return errors.New("This is an error") //nolint:stylecheck
+}
+
+func goodError() error {
+	return errors.New("this is an error")
 }


### PR DESCRIPTION
This change introduces activation of staticcheck ST1005 to golangci-lint
configuration v1.

This is the default when migrating our current configuration to
golangci-lint v2 using `golangci-lint migrate` as discovered when
introducing https://github.com/coopnorge/mage to existing codebases.

ST1005 - Incorrectly formatted error string
Error strings follow a set of guidelines to ensure uniformity and good composability.

Quoting [Go Code Review Comments]:
>
> Error strings should not be capitalized (unless beginning with proper
> nouns or acronyms) or end with punctuation, since they are usually
> printed following other context. That is, use fmt.Errorf("something
> bad") not fmt.Errorf("Something bad"), so that log.Printf("Reading %s:
> %v", filename, err) formats without a spurious capital letter
> mid-message.

According to [staticcheck's default configuration] ST1005 should be
active.

[Go Code Review Comments]: https://go.dev/wiki/CodeReviewComments#error-strings
[staticcheck's default configuration]: https://staticcheck.dev/docs/configuration/#example-configuration