### PR TITLE
chore(deps): Upgrade to golangci-lint v2

### DIFF
--- a/images/devtools-golang-v1beta1/context/.golangci.yml
+++ b/images/devtools-golang-v1beta1/context/.golangci.yml
@@ -1,40 +1,45 @@
-# https://golangci-lint.run/usage/configuration/
-run:
-  timeout: 5m
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-  - contextcheck
-  - errcheck
-  - gofmt
-  - goimports
-  - gosimple
-  - govet
-  - ineffassign
-  - misspell
-  - revive
-  - staticcheck
-  - typecheck
-  - unused
-  - whitespace
-issues:
-  exclude-use-default: false
-  exclude-rules:
-  - path: _test[.]go
-    linters:
-      - errcheck
-    text: "Error return value of.* is not checked"
-  - path: _test[.]go
-    linters:
-      - gosec
-    text: "Potential file inclusion via variable"
-  - linters:
+    - contextcheck
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
     - revive
-    # Igorning package comments warning as most our packages don't have package
-    # comments.
-    text: "package-comments: .*"
-linters-settings:
-  # https://golangci-lint.run/usage/linters/#linters-configuration
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
+    - staticcheck
+    - unused
+    - whitespace
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - errcheck
+        path: _test[.]go
+        text: Error return value of.* is not checked
+      - linters:
+          - gosec
+        path: _test[.]go
+        text: Potential file inclusion via variable
+      - linters:
+          - revive
+        text: 'package-comments: .*'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/safewaters/docker-lock:latest@sha256:432d90ddc2891f4845241adc63e5eef2dd1486fa14ea7882433cbd3f8ed64622 AS docker-lock
-FROM golangci/golangci-lint:v1.64-alpine@sha256:ae6460f78db54f22838d2a8aee0f2eaa4f785d5a01f638600072b60848f8deb4 AS golangci-lint
+FROM golangci/golangci-lint:v2.0-alpine@sha256:66854a432087d43cee95e82406b895f93a2cf6448e3edc67f46ce057dab07c7a AS golangci-lint
 FROM docker.io/fullstorydev/grpcurl:v1.9.3@sha256:085e183ca334eb4e81ca81ee12cbb2b2737505d1d77f5e33dabc5d066593d998 AS grpcurl
 FROM docker.io/mikefarah/yq:4@sha256:2c100efaca06e95ffe452cfe9bfc0048b493f0f3a072d5fe06f828c638d9462b AS yq
 FROM docker.io/hadolint/hadolint:v2.12.0@sha256:30a8fd2e785ab6176eed53f74769e04f125afb2f74a6c52aef7d463583b6d45e AS hadolint

--- a/images/devtools-golang-v1beta1/tests/prototype/main.go
+++ b/images/devtools-golang-v1beta1/tests/prototype/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -10,4 +11,22 @@ import (
 func main() {
 	fmt.Println("2 + 2 =", sum.Sum(2, 2))
 	fmt.Println("os.Args =", os.Args)
+
+	err := badError()
+	if err != nil {
+		panic(err)
+	}
+
+	err = goodError()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func badError() error {
+	return errors.New("This is an error") //nolint:staticcheck
+}
+
+func goodError() error {
+	return errors.New("this is an error")
 }

--- a/images/devtools-golang-v1beta1/tests/test_image.py
+++ b/images/devtools-golang-v1beta1/tests/test_image.py
@@ -205,9 +205,11 @@ func UnusedFunc() int {
                 (
                     lambda workdir: (workdir / ".golangci.yml").write_text(
                         """\
+version: "2"
 linters:
-  disable-all: true
-  enable: [ misspell ]
+  default: none
+  enable:
+    - misspell
 """
                     )
                 ),


### PR DESCRIPTION
This change upgrades Golangci-lint to version 2. With the upgrade brings
changes to several linters ([Full list of changes])

The most notable is the merge of the linters `stylecheck`, `gosimple`,
and `staticcheck` into `staticcheck`, the 3 linters all implement
https://staticcheck.dev/ rules.

The change causes the default rules from `stylecheck` to be active.

https://github.com/coopnorge/mage uses golangci-lint v2 with default
settings for static check. Initial testing of mage has detected violations of
[ST1005]: Incorrectly formatted error string. Further testing might
bring other violations to the surface.

The configuration was migrated using:

 ```console
golangci-lint migrate
```

Closes: https://github.com/coopnorge/engineering-issues/issues/444

[Full list of of changes]: https://golangci-lint.run/product/migration-guide/#changes
