### PR TITLE
docs: Fix the text in the golang-devtools docs

### DIFF
--- a/docs/images/devtools-golang-v1beta1.md
+++ b/docs/images/devtools-golang-v1beta1.md
@@ -21,6 +21,7 @@ configuration must be compatible.
    ```
 
    Make sure to not set a passphrase, and to `Configure SSO` to Authorize the
+   key for use with coopnorge after you have added it to GitHub.
 
 2. Configure git to access the repositories over SSH instead of HTTPS
 
@@ -30,7 +31,7 @@ configuration must be compatible.
 
    ```console title="Coop specific"
    git config --global url."git@github.com:coopnorge/".insteadOf "https://github.com/coopnorge/"
-   ```  key for use with coopnorge after you have added it to GitHub.
+   ```
 
 ### Configuration
 


### PR DESCRIPTION
It seems to have been mistakenly edited here: https://github.com/coopnorge/engineering-docker-images/pull/1248/files