### PR TITLE
docs: Align the documentation with the new template

### DIFF
--- a/docs/images/devtools-golang-v1beta1.md
+++ b/docs/images/devtools-golang-v1beta1.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```console
-docker-compose run --rm golang-devtools help
+docker compose run --rm golang-devtools help
 ```
 
 ### Prerequisites
@@ -48,23 +48,21 @@ are listed in before any variables are defined:
 If `devtools-targets.mk` is present then it will be loaded after all targets are
 defined.
 
-```Dockerfile title="docker-compose/Dockerfile"
-FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-golang-v1beta1:latest@sha256:7e54fe41351af1b7b4cdf75c2cb8251f80b89845b49179ae2003b200b3054369 AS golang-devtools
+```Dockerfile title="devtools/golang.Dockerfile"
+FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-golang-v1beta1:latest@sha256:7e54fe41351af1b7b4cdf75c2cb8251f80b89845b49179ae2003b200b3054369
 ```
 
-```yaml title="docker-compose.yaml"
+```yaml title="devtools/golang.yaml"
 services:
   golang-devtools:
     build:
-      context: docker-compose
-      target: golang-devtools
-      dockerfile: Dockerfile
+      dockerfile: golang.Dockerfile
     privileged: true
     security_opt:
       - seccomp:unconfined
       - apparmor:unconfined
     volumes:
-      - .:/srv/workspace:z
+      - ../:/srv/workspace:z
       - ${DOCKER_CONFIG:-~/.docker}:/root/.docker
       - ${GIT_CONFIG:-~/.gitconfig}:${GIT_CONFIG_GUEST:-/root/.gitconfig}
       - ${SSH_CONFIG:-~/.ssh}:/root/.ssh
@@ -83,6 +81,11 @@ networks:
   default:
 volumes:
     xdg-cache-home: {}
+```
+
+```yaml title="docker-compose.yaml"
+include:
+  - devtools/golang.yaml
 ```
 
 ## Features

--- a/docs/images/devtools-terraform-v1beta1.md
+++ b/docs/images/devtools-terraform-v1beta1.md
@@ -33,7 +33,7 @@
 
 To update tfswitch to the latest version run:
 
-```concole
+```console
 images/devtools-terraform-v1beta1/context/update_tfswitch.py
 ```
 
@@ -46,27 +46,31 @@ latest version number.
 Add the following line to your `devtools/Dockerfile`:
 
 ```Dockerfile title="devtools/Dockerfile"
-FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-terraform-v1beta1:latest@sha256:e18031952ade602b87f5c1a4e6d5b426497b66bac1ff28de28144e00752da94d AS terraform-devtools
+FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-terraform-v1beta1:latest@sha256:e18031952ade602b87f5c1a4e6d5b426497b66bac1ff28de28144e00752da94d
 ```
 
-Then, add the following section to your `docker-compose.yaml`:
+Then, add the following content to `devtools/terraform.yaml`:
 
-```yaml title="docker-compose.yaml"
-version: "3.7"
-
+```yaml title="devtools/terraform.yaml"
 services:
   terraform-devtools:
     build:
-      context: devtools
-      target: terraform-devtools
+      dockerfile: terraform.Dockerfile
     working_dir: /srv/workspace
     command: validate terraform_init_args="-backend=false"
     volumes:
-      - .:/srv/workspace:z
+      - ../:/srv/workspace:z
       - xdg-cache-home:/root/.cache
       - $HOME/.terraform.d:/root/.terraform.d/
 volumes:
   xdg-cache-home: {}
+```
+
+Then, add the following content to `docker-compose.yaml`:
+
+```yaml title="docker-compose.yaml"
+include:
+  - devtools/terraform.yaml
 ```
 
 To make sure that the image hash specified in `Dockerfile` above is updated

--- a/docs/images/techdocs.md
+++ b/docs/images/techdocs.md
@@ -9,22 +9,19 @@ The image is designed to run in a repository containing TechDocs.
 
 ### Docker compose configuration
 
-Add a `docker-compose.yaml` file to the repository.
+Add a `devtools/techdocs.yaml` file to the repository.
 
-```yaml title="docker-compose.yaml"
----
+```yaml title="devtools/techdocs.yaml"
 services:
   techdocs:
     build:
-      context: docker-compose
-      dockerfile: Dockerfile
-      target: techdocs
+      dockerfile: techdocs.Dockerfile
     working_dir: /srv/workspace
     environment:
       GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-}
       GCLOUD_PROJECT: ${GCLOUD_PROJECT:-}
     volumes:
-      - .:/srv/workspace:z
+      - ../:/srv/workspace:z
       - ${XDG_CACHE_HOME:-xdg-cache-home}:/root/.cache
       - $HOME/.config/gcloud:/root/.config/gcloud
       - ${GOOGLE_APPLICATION_CREDENTIALS:-nothing}:${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/empty-GOOGLE_APPLICATION_CREDENTIALS}
@@ -37,8 +34,13 @@ volumes:
   nothing: { }
 ```
 
-```Dockerfile title="docker-compose/Dockerfile"
-FROM ghcr.io/coopnorge/engineering-docker-images/e0/techdocs:latest@sha256:68ce8f1b1745d587dbd542b1e8d4974eacf513ea2adffa1d566e76cca071417c AS techdocs
+```yaml title="docker-compose.yaml"
+include:
+  - devtools/techdocs.yaml
+```
+
+```Dockerfile title="devtools/Dockerfile"
+FROM ghcr.io/coopnorge/engineering-docker-images/e0/techdocs:latest@sha256:68ce8f1b1745d587dbd542b1e8d4974eacf513ea2adffa1d566e76cca071417c
 ```
 
 ### Running a preview site


### PR DESCRIPTION
* `devtools` directory is used instead of `docker-compose`
* `Dockerfile` is broken down into multiple files with each image in a different one
* `docker-compose.yaml` is also broken down into multiple files and included in the `docker-compose.yaml`
ref: https://github.com/coopnorge/backstage/tree/main/software-templates/generic-repository-template/template