### PR TITLE
chore: Restrict dependabot from updating argocd beyond v2.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
     directory: "images/devtools-kubernetes-v1beta1/context/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: argoproj/argocd
+        versions: ">= 2.12"
   - package-ecosystem: "docker"
     directory: "images/devtools-terraform-v1beta1/context/"
     schedule:


### PR DESCRIPTION
We run 2.11

ref: https://github.com/coopnorge/engineering-docker-images/pull/2734

This change is relevant to this issue when we work on it: https://github.com/coopnorge/cloud-platform-team/issues/1058