### PR TITLE
chore: update vale to 3.5.0

### DIFF
--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -1,5 +1,4 @@
 FROM docker.io/library/node:24.3.0-bookworm@sha256:4b383ce285ed2556aa05a01c76305405a3fecd410af56e2d47a039c59bdc2f04 AS node
-FROM jdkato/vale:v3.5.0@sha256:5e15a69cf0590ad03b275cb406156092977af7a11a7bde3b78375c14d907907f AS vale
 FROM plantuml/plantuml:1.2025.4@sha256:227c418ce3811b3bfd48e022922af35839914d606d5ea1c8a4137d77d58d482c AS plantuml
 FROM mikefarah/yq:4.45.4@sha256:7cf28e5d67782f4b274a93a7bc54a840b553447a0807efd843d069f46bff718c AS yq
 FROM docker.io/library/python:3.12.7-bookworm@sha256:db1afbfdc089b792bed227d70e1b1607c16bacb391f1257b7af1f0e6b2384480 AS base
@@ -56,12 +55,18 @@ FROM base AS npm-tools
 
 FROM base AS techdocs-cli
 
-COPY --from=vale /bin/vale /bin/vale
 COPY --from=plantuml /opt/plantuml.jar /opt/plantuml.jar
 COPY --from=yq /usr/bin/yq /usr/bin/yq
 # hadolint ignore=SC2016
 RUN echo $'#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml && \
     chmod 755 /usr/local/bin/plantuml
+
+ENV VALE_VERSION=3.5.0
+
+# hadolint ignore=DL4006
+RUN curl -fsSL https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz \
+    | tar -xz -C /bin --strip-components=0 vale \
+    && chmod +x /bin/vale
 
 COPY package.json package.json
 COPY package-lock.json package-lock.json

--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/library/node:24.3.0-bookworm@sha256:4b383ce285ed2556aa05a01c76305405a3fecd410af56e2d47a039c59bdc2f04 AS node
-FROM jdkato/vale:v3.4.2@sha256:da6a0901858421b282aa8d935e72831c84cebf716ae4e276658e9e5d382fad20 AS vale
+FROM jdkato/vale:v3.5.0@sha256:5e15a69cf0590ad03b275cb406156092977af7a11a7bde3b78375c14d907907f AS vale
 FROM plantuml/plantuml:1.2025.4@sha256:227c418ce3811b3bfd48e022922af35839914d606d5ea1c8a4137d77d58d482c AS plantuml
 FROM mikefarah/yq:4.45.4@sha256:7cf28e5d67782f4b274a93a7bc54a840b553447a0807efd843d069f46bff718c AS yq
 FROM docker.io/library/python:3.12.7-bookworm@sha256:db1afbfdc089b792bed227d70e1b1607c16bacb391f1257b7af1f0e6b2384480 AS base

--- a/images/techdocs/tests/test_image.py
+++ b/images/techdocs/tests/test_image.py
@@ -37,7 +37,7 @@ def volumes() -> dict[str, dict[str, str]]:
     [
         ("techdocs-cli --version", b"1."),
         ("markdownlint --version", b"0."),
-        ("vale --version", b"vale version v3."),
+        ("vale --version", b"vale version 3."),
         ("yq --version", b"yq (https://github.com/mikefarah/yq/) version v4."),
     ],
 )


### PR DESCRIPTION
Change from vale binary from docker image to the one from releases because the one in docker images is now [compiled with CGO_ENABLED=1 on alpine](https://github.com/errata-ai/vale/commit/1a87d113f956796e6df6a9010ebe57e690680624) and is therefore not a standalone binary.

The latest version is 3.11.x, but it seems it may have additional requirements, so updating to 3.5 for now.

This means that dependabot updates will no longer work, and we may have to configure renovatebot at a later date.