### PR TITLE
chore: Remove dependabot update restriction for argocd

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,9 +30,6 @@ updates:
     directory: "images/devtools-kubernetes-v1beta1/context/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: argoproj/argocd
-        versions: ">= 2.12"
   - package-ecosystem: "docker"
     directory: "images/devtools-terraform-v1beta1/context/"
     schedule:


### PR DESCRIPTION
Since we are [updating argocd to 3.x](https://github.com/coopnorge/argocd-deployment/pull/99), and [will keep it up-to-date](https://github.com/coopnorge/argocd-deployment/pull/101/files), it now makes sense to let dependabot update argocd cli to the latest version.