### PR TITLE
chore: Update vale version to 3.7 in techdocs

### DIFF
--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=yq /usr/bin/yq /usr/bin/yq
 RUN echo $'#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml && \
     chmod 755 /usr/local/bin/plantuml
 
-ENV VALE_VERSION=3.6.1
+ENV VALE_VERSION=3.7.1
 
 # hadolint ignore=DL4006
 RUN curl -fsSL https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz \


### PR DESCRIPTION
As discussed here, I am updating the vale version gradually: https://github.com/coopnorge/engineering-docker-images/pull/2825#issuecomment-3031749778