### PR TITLE
golangci lint bump fix

### DIFF
--- a/images/devtools-golang-v1beta1/context/Dockerfile
+++ b/images/devtools-golang-v1beta1/context/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/safewaters/docker-lock:latest@sha256:432d90ddc2891f4845241adc63e5eef2dd1486fa14ea7882433cbd3f8ed64622 AS docker-lock
-FROM golangci/golangci-lint:v2.2-alpine@sha256:d2e03a7601e2ce6fdb611a5d075dc8d18ed76c47460c28567c24f44dc8a260a8 AS golangci-lint
+FROM golangci/golangci-lint:v2.4-alpine@sha256:a93d021e12afdb31b11a3d2dab39cfc45b2ec950977029ffed636e2098cb784c AS golangci-lint
 FROM docker.io/fullstorydev/grpcurl:v1.9.3@sha256:085e183ca334eb4e81ca81ee12cbb2b2737505d1d77f5e33dabc5d066593d998 AS grpcurl
 FROM docker.io/mikefarah/yq:4@sha256:b9285dd3b0bea3c34d0c54415dd48d767dabd9644d489bd6e253660847b58419 AS yq
 FROM docker.io/hadolint/hadolint:2.12.0@sha256:30a8fd2e785ab6176eed53f74769e04f125afb2f74a6c52aef7d463583b6d45e AS hadolint

--- a/images/devtools-golang-v1beta1/tests/test_image.py
+++ b/images/devtools-golang-v1beta1/tests/test_image.py
@@ -136,7 +136,7 @@ def test_prototype_ok(test_helper: TestHelper) -> None:
             (
                 lambda workdir: (workdir / "bad_file.go").write_text(
                     """\
-package main
+package somepackage
 
 func NoDocs() int {
 	return 3
@@ -150,6 +150,28 @@ func init() {
             ),
             [("exported function NoDocs should have comment or be unexported", True)],
             id="validate-exported-comment",
+        ),
+        pytest.param(
+            # Main package does not require comments for exported functions
+            None,
+            True,
+            (
+                lambda workdir: (workdir / "main.go").write_text(
+                    """\
+package main
+
+func NoDocs() int {
+	return 3
+}
+
+func init() {
+	print(NoDocs())
+}
+"""
+                )
+            ),
+            [("exported function NoDocs should have comment or be unexported", False)],
+            id="validate-exported-comment-main",
         ),
         pytest.param(
             None,


### PR DESCRIPTION
- **build(deps): bump golangci/golangci-lint**
- **test: Fix validate-exported-comment for main package**
