### PR TITLE
feat(techdocs): Add Prettier as formatter for markdown files

### DIFF
--- a/images/techdocs/context/.prettierrc
+++ b/images/techdocs/context/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "printWidth": 80,
+    "tabWidth": 2,
+    "useTabs": false,
+    "endOfLine": "lf",
+    "proseWrap": "always"
+}

--- a/images/techdocs/context/.prettierrc
+++ b/images/techdocs/context/.prettierrc
@@ -1,7 +1,14 @@
 {
-    "printWidth": 80,
-    "tabWidth": 2,
-    "useTabs": false,
-    "endOfLine": "lf",
-    "proseWrap": "always"
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "printWidth": 80,
+        "tabWidth": 2,
+        "useTabs": false,
+        "endOfLine": "lf",
+        "proseWrap": "always"
+      }
+    }
+  ]
 }

--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -93,6 +93,8 @@ RUN \
     ln -rs /usr/local/bin/maker /usr/local/bin/lint-fix && \
     ln -rs /usr/local/bin/maker /usr/local/bin/lint && \
     ln -rs /usr/local/bin/maker /usr/local/bin/linguistics-check && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/format-fix && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/format && \
     ln -rs /usr/local/bin/maker /usr/local/bin/build && \
     ln -rs /usr/local/bin/maker /usr/local/bin/serve && \
     ln -rs /usr/local/bin/maker /usr/local/bin/publish && \
@@ -101,6 +103,7 @@ RUN \
 COPY Makefile /usr/local/share/techdocs/Makefile
 COPY mkdocs.yml /usr/local/share/techdocs/mkdocs.yml
 COPY markdownlint.yaml /usr/local/share/techdocs/markdownlint.yaml
+COPY .prettierrc /usr/local/share/techdocs/.prettierrc
 
 RUN git config --system --add safe.directory /srv/workspace
 

--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /usr/local/share/techdocs
 RUN apt-get clean \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
-        apt-transport-https=2.6.1 \
-        git \
-        lsb-release=12.0-1 \
-        graphviz \
+    apt-transport-https=2.6.1 \
+    git \
+    lsb-release=12.0-1 \
+    graphviz \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -93,8 +93,8 @@ RUN \
     ln -rs /usr/local/bin/maker /usr/local/bin/lint-fix && \
     ln -rs /usr/local/bin/maker /usr/local/bin/lint && \
     ln -rs /usr/local/bin/maker /usr/local/bin/linguistics-check && \
+    ln -rs /usr/local/bin/maker /usr/local/bin/format-check && \
     ln -rs /usr/local/bin/maker /usr/local/bin/format-fix && \
-    ln -rs /usr/local/bin/maker /usr/local/bin/format && \
     ln -rs /usr/local/bin/maker /usr/local/bin/build && \
     ln -rs /usr/local/bin/maker /usr/local/bin/serve && \
     ln -rs /usr/local/bin/maker /usr/local/bin/publish && \

--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -101,6 +101,21 @@ vale-sync:
 linguistics-check: validate-pwd vale-sync ## Check spelling, grammar and other linguistics issues
 	vale $(MARKDOWN_FILES)
 
+../.prettierrc:
+	if [ -s ..prettierrc ]; then \
+	    yq '. *= load("..prettierrc")' /usr/local/share/techdocs/.prettierrc > $@ ;\
+	else \
+	    cp /usr/local/share/techdocs/.prettierrc $@ ;\
+	fi
+
+.PHONY: format
+format: validate-pwd ../.prettierrc ## Check markdown formatting
+	prettier --check --config ../.prettierrc $(MARKDOWN_FILES)
+
+.PHONY: format-fix
+format-fix: ../.prettierrc ## Fix auto-fixable markdown formatting issues
+	prettier --write --config ../.prettierrc $(MARKDOWN_FILES)
+
 SITE_NAME := $(shell yq --no-doc 'select(document_index == 0) | .metadata.title // .metadata.name' ./catalog-info.yaml)
 REPO_NAME := $(shell yq --no-doc 'select(document_index == 0) | .metadata.annotations."github.com/project-slug"' ./catalog-info.yaml)
 ENTITY := $(shell yq --no-doc 'select(document_index == 0) | [.metadata.namespace // "default", .kind, .metadata.name] | join("/")' ./catalog-info.yaml)

--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -108,8 +108,8 @@ linguistics-check: validate-pwd vale-sync ## Check spelling, grammar and other l
 	    cp /usr/local/share/techdocs/.prettierrc $@ ;\
 	fi
 
-.PHONY: format
-format: validate-pwd ../.prettierrc ## Check markdown formatting
+.PHONY: format-check
+format-check: validate-pwd ../.prettierrc ## Check markdown formatting
 	prettier --check --config ../.prettierrc $(MARKDOWN_FILES)
 
 .PHONY: format-fix

--- a/images/techdocs/context/package-lock.json
+++ b/images/techdocs/context/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "workspace",
+  "name": "context",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -7,7 +7,8 @@
       "dependencies": {
         "@techdocs/cli": "1.9.8",
         "markdownlint": "^0.38.0",
-        "markdownlint-cli": "^0.45.0"
+        "markdownlint-cli": "^0.45.0",
+        "prettier": "3.6.2"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -9584,6 +9585,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process": {
@@ -19635,6 +19651,11 @@
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       }
+    },
+    "prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="
     },
     "process": {
       "version": "0.11.10",

--- a/images/techdocs/context/package.json
+++ b/images/techdocs/context/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@techdocs/cli": "1.9.8",
     "markdownlint": "^0.38.0",
-    "markdownlint-cli": "^0.45.0"
+    "markdownlint-cli": "^0.45.0",
+    "prettier": "3.6.2"
   }
 }


### PR DESCRIPTION
The TechDocs image does not have a formatter, but a very strict linting of formatting rules (like a max length of 80 characters per line). This PR adds a standardized formatter [Prettier](https://prettier.io/) to the tooling, **without** running it as part of `validate` and `validate-fix` yet. This will let us be able to run the formatter on a couple repos, to assess better if there are any major conflicts between Prettier and Markdownlint that needs to be resolved.

Part of #3054
