### PR TITLE
chore: Pin mage and dyff versions in devtools-kubernetes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,6 +29,28 @@
       "versioningTemplate": "deb",
       // if we change the debian base image (e.g. FROM docker.io/library/python:x.y.z-bookworm), we need to change the suite string below
       "registryUrlTemplate": "https://deb.debian.org/debian?suite=bookworm&components=main&binaryArch=amd64"
+    },
+    // mage version in devtools-kubernetes
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^images/devtools-kubernetes-v1beta1/context/Dockerfile$/"],
+      "matchStrings": [
+          "ENV\\s+MAGE_VERSION\\s*=\\s*(?<currentValue>[0-9.]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "magefile/mage",
+      "versioningTemplate": "semver",
+    },
+    // dyff version in devtools-kubernetes
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^images/devtools-kubernetes-v1beta1/context/Dockerfile$/"],
+      "matchStrings": [
+          "ENV\\s+DYFF_VERSION\\s*=\\s*(?<currentValue>[0-9.]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "homeport/dyff",
+      "versioningTemplate": "semver",
     }
   ]
 }

--- a/images/devtools-kubernetes-v1beta1/context/Dockerfile
+++ b/images/devtools-kubernetes-v1beta1/context/Dockerfile
@@ -10,15 +10,20 @@ FROM golang:1.25.1@sha256:8305f5fa8ea63c7b5bc85bd223ccc62941f852318ebfbd22f53bbd
 
 COPY --from=yq /usr/bin/yq /usr/local/bin/yq
 
+ENV MAGE_VERSION=v1.15.0
+ENV DYFF_VERSION=v1.10.2
+
 WORKDIR /build
 COPY go.mod go.sum tools.go /build/
+# hadolint ignore=DL3062
 RUN \
-    cd $(go mod download -json github.com/magefile/mage | yq .Dir)  && \
+    cd $(go mod download -json "github.com/magefile/mage@$MAGE_VERSION" | yq .Dir)  && \
     go run bootstrap.go
 
 WORKDIR /build
+# hadolint ignore=DL3062
 RUN \
-    cd $(go mod download -json github.com/homeport/dyff | yq .Dir)/cmd/dyff  && \
+    cd $(go mod download -json "github.com/homeport/dyff@$DYFF_VERSION" | yq .Dir)/cmd/dyff  && \
     go build -o /go/bin/dyff
 
 RUN \


### PR DESCRIPTION
Pinning still results in hadolint errors, so have added ignore.

Adding renovate entries to update them, but they will not work until https://github.com/coopnorge/cloud-platform-apis/issues/262 is fixed
