### PR TITLE
fix: Allow proper merging if repo already contains prettierrc

### DIFF
--- a/images/techdocs/context/Dockerfile
+++ b/images/techdocs/context/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get clean \
     git \
     lsb-release=12.0-1 \
     graphviz \
+    jq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -104,6 +105,7 @@ COPY Makefile /usr/local/share/techdocs/Makefile
 COPY mkdocs.yml /usr/local/share/techdocs/mkdocs.yml
 COPY markdownlint.yaml /usr/local/share/techdocs/markdownlint.yaml
 COPY .prettierrc /usr/local/share/techdocs/.prettierrc
+COPY merge_prettier_configs.sh /usr/local/share/techdocs/merge_prettier_configs.sh
 
 RUN git config --system --add safe.directory /srv/workspace
 

--- a/images/techdocs/context/Makefile
+++ b/images/techdocs/context/Makefile
@@ -102,8 +102,8 @@ linguistics-check: validate-pwd vale-sync ## Check spelling, grammar and other l
 	vale $(MARKDOWN_FILES)
 
 ../.prettierrc:
-	if [ -s ..prettierrc ]; then \
-	    yq '. *= load("..prettierrc")' /usr/local/share/techdocs/.prettierrc > $@ ;\
+	if [ -s .prettierrc ]; then \
+		/usr/local/share/techdocs/merge_prettier_configs.sh .prettierrc /usr/local/share/techdocs/.prettierrc $@ ;\
 	else \
 	    cp /usr/local/share/techdocs/.prettierrc $@ ;\
 	fi

--- a/images/techdocs/context/merge_prettier_configs.sh
+++ b/images/techdocs/context/merge_prettier_configs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Saner programming environment. Turns common developer mistakes into errors.
+set -eu -o pipefail
+
+if [[ $# -ne 3 ]]; then
+    echo "Not the right number of arguments. Got $# but expected 3."
+    exit 1
+fi
+
+BASE_CONFIG_PATH="$1"
+TECHDOCS_CONFIG_PATH="$2"
+OUTPUT_PATH="$3"
+
+# Exit if you don't have jq
+command -v jq >/dev/null 2>&1 || {
+  echo "This script requires jq: https://github.com/jqlang/jq" >&2
+  exit 2
+}
+
+jq -s '
+  .[0] as $base |
+  .[1] as $techdocs |
+  $base |
+  .overrides = (
+    # Start with base overrides
+    .overrides as $baseOverrides |
+    # Get techdocs overrides
+    ($techdocs.overrides // []) as $techdocsOverrides |
+    
+    # For each base override, check if there is a matching techdocs override
+    ($baseOverrides | map(
+      . as $baseItem |
+      # Find matching techdocs override by files property
+      ($techdocsOverrides | map(select(.files == $baseItem.files)) | .[0]) as $matchingtechdocs |
+      if $matchingtechdocs then
+        # Merge options from both
+        $baseItem | .options = ($baseItem.options + $matchingtechdocs.options)
+      else
+        # Keep base override as is
+        $baseItem
+      end
+    )) +
+    # Add techdocs overrides that dont match any base override
+    ($techdocsOverrides | map(
+      . as $techdocsItem |
+      if ($baseOverrides | map(.files) | index($techdocsItem.files)) == null then
+        $techdocsItem
+      else
+        empty
+      end
+    ))
+  )
+' "$BASE_CONFIG_PATH" "$TECHDOCS_CONFIG_PATH" > "$OUTPUT_PATH"
+
+echo "Merged config written to $OUTPUT_PATH"


### PR DESCRIPTION
There was a typo bug with the previous merging of configs, and the same method of merging configs that markdownlint does not work for prettier, since its a more complicated structure
