### PR TITLE
chore: Remove xdg cache

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,8 +1,6 @@
 on:
   push: {}
   workflow_dispatch: {}
-env:
-  XDG_CACHE_HOME: ${{ github.workspace }}/.cache/xdg
 jobs:
 
   setup:
@@ -83,13 +81,6 @@ jobs:
         image: ${{ fromJSON(needs.setup.outputs.image-names) }}
     steps:
       - uses: actions/checkout@v5
-      - name: Cache xdg
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.XDG_CACHE_HOME }}
-          key: xdg-v1-${{ hashFiles('**/Makefile') }}
-          restore-keys: |
-            xdg-v1-
       - name: Install poetry
         run: pipx install poetry
       - name: Setup Python


### PR DESCRIPTION
For some reason, having this enabled fails some PRs, eg.: https://github.com/coopnorge/engineering-docker-images/pull/3053

This seems to be used for python caching. We use caching from setup-python, so this may no longer help us anyway.