### PR TITLE
Add support for Grids in documentation

### DIFF
--- a/images/techdocs/context/mkdocs.yml
+++ b/images/techdocs/context/mkdocs.yml
@@ -30,6 +30,7 @@ markdown_extensions:
   - github-callouts
   - admonition
   - attr_list
+  - md_in_html
   - pymdownx.details
   - pymdownx.highlight:
       use_pygments: true


### PR DESCRIPTION
This changes enables [Grids][1]. Grids group blocks that convey similar
meaning or are of equal importance.

[1]: https://squidfunk.github.io/mkdocs-material/reference/grids/
