### PR TITLE
chore: Add techdocs-ref for component devtools-terraform-v1beta1 in catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -63,6 +63,7 @@ metadata:
   name: devtools-terraform-v1beta1
   annotations:
     github.com/project-slug: coopnorge/engineering-docker-images
+    backstage.io/techdocs-ref: dir:.
   tags:
     - devtools
     - terraform


### PR DESCRIPTION
Documentation is missing here: https://inventory.internal.coop/catalog/default/component/devtools-terraform-v1beta1/docs