### PR TITLE
chore: Add self-hosted renovate bot to policy bot config

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -25,6 +25,7 @@ approval_rules:
       users:
       - "dependabot[bot]"
       - "renovate-coop-norge[bot]"
+      - "renovatebot-coopnorge[bot]"
     only_changed_files:
       paths:
       - ".*Dockerfile$"


### PR DESCRIPTION
Alongside dependabot