### PR TITLE
fix: Commit message suffix is not working as expected in renovatebot updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -20,7 +20,7 @@
         },
         {
             "matchPaths": ["images/**"],
-            "commitMessageSuffix": " in {{{lookup (split parentDir \"/\") 1}}}"
+            "commitMessageSuffix": " in {{{lookup (split packageFileDir \"/\") 1}}}"
         },
         {
             "matchPaths": ["images/poetry-python3.9/**"],


### PR DESCRIPTION
e.g. https://github.com/coopnorge/engineering-docker-images/pull/3380
