### PR TITLE
chore: Limit poetry version to v1

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,9 +19,10 @@
             "allowedVersions": "< 1.6.0"
         },
         {
-            "matchFileNames": ["images/**"],
-            "additionalBranchPrefix": "{{{lookup (split packageFileDir \"/\") 1}}}-",
-            "commitMessageSuffix": " in {{{lookup (split packageFileDir \"/\") 1}}}"
+            "matchPackageNames": ["poetry"],
+            "matchManagers": ["pip-compile", "pip_setup", "pip_requirements"],
+            "matchFileNames": ["images/**/*python*/**"],
+            "allowedVersions": "< 2.0.0"
         },
         {
             "matchFileNames": ["images/poetry-python3.9/**"],


### PR DESCRIPTION
Poetry update is a big change and since we are no longer developing these images, it makes sense to keep it at v1. The existing tests check for v1 and don't allow v2 anyway.