### PR TITLE
chore: Separate dependencies in different image directories

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -20,6 +20,7 @@
         },
         {
             "matchPaths": ["images/**"],
+            "additionalBranchPrefix": "{{{lookup (split packageFileDir \"/\") 1}}}-",
             "commitMessageSuffix": " in {{{lookup (split packageFileDir \"/\") 1}}}"
         },
         {


### PR DESCRIPTION
This combines updates, which can fail for certain updates:
https://github.com/coopnorge/engineering-docker-images/pull/3396
