### PR TITLE
chore: Add python version constraints in addition to allowedVersions (renovatebot config)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,17 +26,26 @@
         {
             "matchPaths": ["images/poetry-python3.9/**"],
             "matchPackageNames": ["python"],
-            "allowedVersions": "3.9.x"
+            "allowedVersions": "3.9.x",
+            "constraints": {
+                "python": "3.9"
+            },
         },
         {
             "matchPaths": ["images/poetry-python3.10/**", "images/devtools-python3.10-v1beta1/**"],
             "matchPackageNames": ["python"],
-            "allowedVersions": "3.10.x"
+            "allowedVersions": "3.10.x",
+            "constraints": {
+                "python": "3.10"
+            },
         },
         {
             "matchPaths": ["images/poetry-python3.11/**"],
             "matchPackageNames": ["python"],
-            "allowedVersions": "3.11.x"
+            "allowedVersions": "3.11.x",
+            "constraints": {
+                "python": "3.11"
+            },
         },
     ],
     "customManagers": [


### PR DESCRIPTION
I am wondering if renovate is not using the correct python version despite existence of .python-version. I see this:

> 10.66 ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
> 10.66     typing-extensions>=4.13.2 from https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl (from virtualenv==20.36.1->-r requirements.txt (line 697))
> ------
> Dockerfile:21
> --------------------
>   20 |     
>   21 | >>> RUN python3 -m venv $POETRY_HOME && \
>   22 | >>>     $POETRY_HOME/bin/pip install \
>   23 | >>>         --no-cache-dir \
>   24 | >>>         --require-hashes  \
>   25 | >>>         --verbose \
>   26 | >>>         --use-pep517 \
>   27 | >>>         --requirement requirements.txt && \
>   28 | >>>     rm -rf requirements.txt
>   29 |     
> --------------------
> ERROR: failed to build: failed to solve: process "/bin/sh -c python3 -m venv $POETRY_HOME &&     $POETRY_HOME/bin/pip install         --no-cache-dir         --require-hashes          --verbose         --use-pep517         --requirement requirements.txt &&     rm -rf requirements.txt" did not complete successfully: exit code: 1
> make: *** [Makefile:100: build-image-poetry-python3.9] Error 1

ref: https://github.com/coopnorge/engineering-docker-images/pull/3411