### PR TITLE
chore: Restore separate dependencies in different image directories

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,11 @@
             "allowedVersions": "< 1.6.0"
         },
         {
+            "matchFileNames": ["images/**"],
+            "additionalBranchPrefix": "{{{lookup (split packageFileDir \"/\") 1}}}-",
+            "commitMessageSuffix": " in {{{lookup (split packageFileDir \"/\") 1}}}"
+        },
+        {
             "matchPackageNames": ["poetry"],
             "matchManagers": ["pip-compile", "pip_setup", "pip_requirements"],
             "matchFileNames": ["images/**/*python*/**"],


### PR DESCRIPTION
Originally added here: https://github.com/coopnorge/engineering-docker-images/pull/3404

Accidentally removed here when resolving merge conflicts: https://github.com/coopnorge/engineering-docker-images/pull/3398