### PR TITLE
chore: Limit poetry-core < 2.0.0

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -27,7 +27,7 @@
             "commitMessageSuffix": " in {{{lookup (split packageFileDir \"/\") 1}}}"
         },
         {
-            "matchPackageNames": ["poetry"],
+            "matchPackageNames": ["poetry", "poetry-core"],
             "matchManagers": ["pip-compile", "pip_setup", "pip_requirements"],
             "matchFileNames": ["images/**/*python*/**"],
             "allowedVersions": "< 2.0.0"


### PR DESCRIPTION
Poetry is set to be <2 (https://github.com/coopnorge/engineering-docker-images/pull/3398) so poetry-core also shouldn't be updated.