### PR TITLE
fix: Separate blocks for allowedVersions and constrains (renovate)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -47,9 +47,19 @@
         },
         {
             "matchFileNames": ["images/poetry-python3.9/**"],
-            "matchPackageNames": ["python", "docker.io/library/python"],
-            "allowedVersions": "3.9.x",
             "constraints": {"python": "3.9"}
+        },
+        {
+            "matchFileNames": ["images/poetry-python3.9/**"],
+            "matchPackageNames": ["python", "docker.io/library/python"],
+            "allowedVersions": "3.9.x"
+        },
+        {
+            "matchFileNames": [
+                "images/poetry-python3.10/**",
+                "images/devtools-python3.10-v1beta1/**",
+            ],
+            "constraints": {"python": "3.10"}
         },
         {
             "matchFileNames": [
@@ -57,14 +67,16 @@
                 "images/devtools-python3.10-v1beta1/**",
             ],
             "matchPackageNames": ["python", "docker.io/library/python"],
-            "allowedVersions": "3.10.x",
-            "constraints": {"python": "3.10"}
+            "allowedVersions": "3.10.x"
+        },
+        {
+            "matchFileNames": ["images/poetry-python3.11/**"],
+            "constraints": {"python": "3.11"}
         },
         {
             "matchFileNames": ["images/poetry-python3.11/**"],
             "matchPackageNames": ["python", "docker.io/library/python"],
-            "allowedVersions": "3.11.x",
-            "constraints": {"python": "3.11"}
+            "allowedVersions": "3.11.x"
         }
     ],
     "customManagers": [


### PR DESCRIPTION
pip-compile updates are being done with wrong python version, e.g. https://github.com/coopnorge/engineering-docker-images/pull/3540/changes
