### PR TITLE
fix: Remove constraints to see if the auto-discovery of version from header works (renovate)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -47,10 +47,6 @@
         },
         {
             "matchFileNames": ["images/poetry-python3.9/**"],
-            "constraints": {"python": "3.9"}
-        },
-        {
-            "matchFileNames": ["images/poetry-python3.9/**"],
             "matchPackageNames": ["python", "docker.io/library/python"],
             "allowedVersions": "3.9.x"
         },
@@ -59,19 +55,8 @@
                 "images/poetry-python3.10/**",
                 "images/devtools-python3.10-v1beta1/**",
             ],
-            "constraints": {"python": "3.10"}
-        },
-        {
-            "matchFileNames": [
-                "images/poetry-python3.10/**",
-                "images/devtools-python3.10-v1beta1/**",
-            ],
             "matchPackageNames": ["python", "docker.io/library/python"],
             "allowedVersions": "3.10.x"
-        },
-        {
-            "matchFileNames": ["images/poetry-python3.11/**"],
-            "constraints": {"python": "3.11"}
         },
         {
             "matchFileNames": ["images/poetry-python3.11/**"],


### PR DESCRIPTION
Documentation says it should work: https://docs.renovatebot.com/modules/manager/pip-compile/#configuration-of-python-version

With constraints, it is somehow not working. ref: https://github.com/coopnorge/engineering-docker-images/pull/3551/changes/cce8397ea1b2a65a7210b2d8b702c17f71c287f7
