### PR TITLE
chore: Loosely define dependency version (techdocs)

### DIFF
--- a/images/techdocs/context/requirements-techdocs.in
+++ b/images/techdocs/context/requirements-techdocs.in
@@ -8,4 +8,4 @@ mkdocs-kroki-plugin==1.2.0
 mkdocs-link-marker==0.2.0
 mkdocs-table-reader-plugin==3.1.0
 mkdocs-techdocs-core==1.5.4
-pymdown-extensions==10.14.3
+pymdown-extensions>=10.14.3


### PR DESCRIPTION
Too strict definition of version here is causing version resolution errors when being updated: https://github.com/coopnorge/engineering-docker-images/pull/3557

We have a lockfile for exact version anyway.