### PR TITLE
chore: Group pymdown-extensions with mkdocs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -34,7 +34,7 @@
             versioning: 'pep440'
         },
         {
-            "matchPackageNames": ["mkdocs-*"],
+            "matchPackageNames": ["mkdocs-*", "pymdown-extensions"],
             "matchFileNames": ["images/techdocs/**"],
             "groupName": "mkdocs dependencies"
         },


### PR DESCRIPTION
pymdown-extensions is a sub-dependency of some mkdown plugins and version resolution may fail if only one of them is updated, e.g. https://github.com/coopnorge/engineering-docker-images/pull/3557
