### PR TITLE
chore(deps): update Go directive to 1.26.0

### DIFF
--- a/images/devtools-golang-v1beta1/context/go.mod
+++ b/images/devtools-golang-v1beta1/context/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/engineering-docker-images/images/devtools-golang-v1beta1/context/gotools
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/abice/go-enum v0.9.2

--- a/images/devtools-golang-v1beta1/tests/prototype/go.mod
+++ b/images/devtools-golang-v1beta1/tests/prototype/go.mod
@@ -1,3 +1,3 @@
 module example.com/prototype
 
-go 1.25.0
+go 1.26.0

--- a/images/devtools-kubernetes-v1beta1/context/go.mod
+++ b/images/devtools-kubernetes-v1beta1/context/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/engineering-docker-images/images/devtools-kubernetes-v1beta1/context/gotools
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/homeport/dyff v1.11.3


### PR DESCRIPTION
Go 1.24 is no longer supported. Update the Go directive to 1.26.0
to comply with the Coop Norge Go language guidelines requiring use
of a supported Go release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
